### PR TITLE
generated asset link HTML has full webroot path

### DIFF
--- a/views/helpers/asset_compress.php
+++ b/views/helpers/asset_compress.php
@@ -370,7 +370,9 @@ class AssetCompressHelper extends AppHelper {
 		if (empty($matching)) {
 			return false;
 		}
-		return $matching[0];
+		
+		//Remove the webroot from the path, so that it is a true URL
+		return DS.str_replace(WWW_ROOT, '', $matching[0]);
 	}
 
 /**


### PR DESCRIPTION
This problem is best explained with an example.

If my css cachePath = WEBROOT/cache_css/ (where WEBROOT=/var/www/blah ) and I do a echo $this->AssetCompress->css('common.css'); the resulting HTML is:

``` html
<link href="/var/www/blah/cache_css/common.v1308759848.css" type="text/css" rel="stylesheet">
```

The href should not include my webroot, so it should be:

``` html
<link href="/cache_css/common.v1308759848.css" type="text/css" rel="stylesheet">
```

The attached pull fixes the problem if user has WEBROOT or the full webroot path explicitly in their cachePath ini directive.

Is putting something other then WEBROOT/foo supported for the cachePath directive? If so, I don't know how a href URL relative to the web servers document root can be generated.
