### PR TITLE
Google Closure compiler support

### DIFF
--- a/libs/filter/closure_js.php
+++ b/libs/filter/closure_js.php
@@ -5,6 +5,8 @@ App::import('Lib', 'AssetCompress.AssetFilter');
  * A Google Closure compressor adapter for compressing Javascript.
  * This filter assumes you have Java installed on your system and that its accessible
  * via the PATH. It also assumes that the compiler.jar file is located in "vendors/closure" directory.
+ * 
+ * You can get closure here at http://code.google.com/closure/compiler/
  *
  * @package asset_compress.libs.filter
  */


### PR DESCRIPTION
I started using Closure because its makes smaller and faster JS than YUI.  Also really like how its parses your JS and gives you nice warning/error messages.

This pull adds a Closure compiler JS filter
