### PR TITLE
Use forward slash instead of DS, breaks links on windows systems

### DIFF
--- a/views/helpers/asset_compress.php
+++ b/views/helpers/asset_compress.php
@@ -330,7 +330,7 @@ class AssetCompressHelper extends AppHelper {
 			//If a timestampFile is being used, don't spend time looking on the local filesystem.
 			$ts = $this->_Config->readTimestampFile();
 			$path = $this->_Config->cachePath('js');
-			$path = DS . str_replace(WWW_ROOT, '', $path);
+			$path = '/' . str_replace(WWW_ROOT, '', $path);
 			$name = substr($file, 0, strlen($file) - (3));
 			$route = $path . $name . '.v' . $ts . '.js';
 		} else {


### PR DESCRIPTION
Hi Mark,

Just installed the newest version of asset compress, really neat new features!
I'm working on a windows system, and had some trouble installing the new asset compress plugin. Because of using older versions i was used to some older settings.

After i got my assets correctly compressed the plugin would not output the correct link. Then while looking at the source code i spotted a DS for creating a url, thats why cake would append "/css/" and create the following url "/css/\cache_css/default.v1315777625.css".

I guess changing the DS to a forward slash should be enough :)
