### PR TITLE
Moving option to disable auto inclusion of view js files to helper config

### DIFF
--- a/tests/cases/helpers/asset_compress.test.php
+++ b/tests/cases/helpers/asset_compress.test.php
@@ -370,4 +370,32 @@ class AssetCompressHelperTestCase extends CakeTestCase {
 		);
 		$this->assertTags($result, $expected);
 	}
+
+/**
+ * test auto inclusion of view js files
+ *
+ * @return void
+ */
+	function testAutoInclusion() {
+		$config = $this->Helper->config();
+		$config->paths('js', array(dirname(dirname(dirname(__FILE__))) . DS . 'test_files' . DS . 'js' . DS));
+		
+		$this->Helper->config($config);
+		$this->Helper->params = array(
+			'controller' => 'posts',
+			'action' => 'add'
+		);
+		$this->Helper->afterRender();
+		
+		$hash = md5('views/posts/add');
+		$result = $this->Helper->includeAssets();
+		$expected = array(
+			'script' => array(
+				'type' => 'text/javascript',
+				'src' => '/asset_compress/assets/get/' . $hash . '.js?file%5B0%5D=views%2Fposts%2Fadd'
+			),
+			'/script'
+		);
+		$this->assertTags($result, $expected);
+	}
 }

--- a/tests/test_files/js/views/posts/add.js
+++ b/tests/test_files/js/views/posts/add.js
@@ -1,0 +1,4 @@
+//= require "base_class"
+var PostsAdd = BaseClass.extend({
+
+});


### PR DESCRIPTION
- So there is no need to extra work in case someone wants to disable it (ie. implementing a beforeFilter/beforeRender into the controller to disable it).
- The files are also included using AssetCompress->addScript(), so if there is any '//= require' it will also identify and include them.
- In order to create the tests was needed to instantialize AssetScanner
