### PR TITLE
Output which file was not found if debug is on

### DIFF
--- a/Controller/AssetsController.php
+++ b/Controller/AssetsController.php
@@ -51,7 +51,8 @@ class AssetsController extends AssetCompressAppController {
 				$Cache->write($build, $contents);
 			}
 		} catch (Exception $e) {
-			throw new NotFoundException();
+			$message = (Configure::read('debug') > 0) ? $e->getMessage() : '';
+			throw new NotFoundException($message);
 		}
 		
 		$this->response->type($Config->getExt($build));


### PR DESCRIPTION
If an included file is not found and debug is > 0, then this will show the path of the file that was not found, rather than a generic not found error.
