### PR TITLE
Fix notice when theme folder contain a dot folder.

### DIFF
--- a/Console/Command/AssetCompressShell.php
+++ b/Console/Command/AssetCompressShell.php
@@ -155,7 +155,7 @@ class AssetCompressShell extends Shell {
 		foreach ($viewpaths as $path) {
 			if (is_dir($path . 'Themed')) {
 				$Folder = new Folder($path . 'Themed');
-				list($dirs, $files) = $Folder->read();
+				list($dirs, $files) = $Folder->read(false, true);
 				$themes = array_merge($themes, $dirs);
 			}
 		}


### PR DESCRIPTION
There was `.svn` folder:

Notice Error: Undefined offset: 1 in Console\Command\AssetCompressShell.php, line 135]
