### PR TITLE
Paths support added to LessCss Filter

### DIFF
--- a/Lib/Filter/LessCss.php
+++ b/Lib/Filter/LessCss.php
@@ -27,7 +27,7 @@ class LessCss extends AssetFilter {
 		if (substr($filename, strlen($this->_settings['ext']) * -1) !== $this->_settings['ext']) {
 			return $input;
 		}
-		
+
 		$tmpfile = tempnam(sys_get_temp_dir(), 'asset_compress_less');
 		$this->_generateScript($tmpfile, $input);
 
@@ -41,20 +41,19 @@ class LessCss extends AssetFilter {
 	protected function _generateScript($file, $input) {
 		$text = <<<JS
 var less = require('less'),
-	sys = require('util');
+	util = require('util');
 
 var parser = new less.Parser({ paths: %s });
 parser.parse(%s, function (e, tree) {
 	if (e) {
 		less.writeError(e);
 		process.exit(1)
-	}
-	
-	sys.print(tree.toCSS());	
+	}	
+	util.print(tree.toCSS());	
 	process.exit(0);
 });
 JS;
 		file_put_contents($file, sprintf($text, str_replace('\/*', '', json_encode($this->_settings['paths'])), json_encode($input)));
-	
+
 	}
 }


### PR DESCRIPTION
This should fix the `@import`s inside less files (they just didn't work, right?). On the other side the imported files are not exposed to previous filters, this can be easily fixed by calling this Filter before any Minifier.
