### PR TITLE
Fix parameter count of includeJs and includeCss

### DIFF
--- a/View/Helper/AssetCompressHelper.php
+++ b/View/Helper/AssetCompressHelper.php
@@ -211,9 +211,9 @@ class AssetCompressHelper extends AppHelper {
  * @return string A string containing asset tags.
  */
 	protected function _genericInclude($files, $ext) {
-		$numArgs = count($files) - 1;
+		$numArgs = count($files);
 		$options = array();
-		if (isset($files[$numArgs]) && is_array($files[$numArgs])) {
+		if (isset($files[$numArgs - 1]) && is_array($files[$numArgs - 1])) {
 			$options = array_pop($files);
 			$numArgs -= 1;
 		}


### PR DESCRIPTION
When passing parameters to includeJs or includeCss, it was including one less file than was passed to it. This commit fixes the parameter count, so `echo $this->AssetCompress->includeJs('core.js');` works.
