### PR TITLE
Fix for AssetScanner, _generateTree method.

### DIFF
--- a/Lib/AssetScanner.php
+++ b/Lib/AssetScanner.php
@@ -90,6 +90,9 @@ class AssetScanner {
  */
 	protected function _generateTree($path) {
 		$paths = glob($path, GLOB_ONLYDIR);
+		if (!$paths) {
+			$paths = array();
+		}
 		array_unshift($paths, dirname($path));
 		return $paths;
 	}


### PR DESCRIPTION
Expected result for glob() function is empty array, false is given instead.

Workaround added. PHP note: On some systems it is impossible to distinguish
between empty match and an error.
