### PR TITLE
Fix issue with path generated on windows for auto included js scripts.

### DIFF
--- a/View/Helper/AssetCompressHelper.php
+++ b/View/Helper/AssetCompressHelper.php
@@ -134,7 +134,7 @@ class AssetCompressHelper extends AppHelper {
 		foreach ($files as $file) {
 			$includeFile = JS . $this->options['autoIncludePath'] . DS . $file;
 			if (file_exists($includeFile)) {
-				$this->Html->script($this->options['autoIncludePath'] . '/' . $file, array('inline' => false));
+				$this->Html->script(str_replace(DS, '/', $this->options['autoIncludePath'] . '/' . $file), array('inline' => false));
 			}
 		}
 	}


### PR DESCRIPTION
The path to js files looked like 'views\controllername\action.js' and browser dont load it.
This changeset fix it
