### PR TITLE
AssetCompressor should always stop propagation, effectively handling the live span of a asset request

### DIFF
--- a/Routing/Filter/AssetCompressor.php
+++ b/Routing/Filter/AssetCompressor.php
@@ -59,7 +59,6 @@ class AssetCompressor extends DispatcherFilter {
 			$mtime = $Compiler->getLastModified($build);
 			$event->data['response']->modified($mtime);
 			if ($event->data['response']->checkNotModified($event->data['request'])) {
-				$event->data['response']->notModified();
 				$event->stopPropagation();
 				return $event->data['response'];
 			}

--- a/Test/Case/Routing/Filter/AssetCompressorTest.php
+++ b/Test/Case/Routing/Filter/AssetCompressorTest.php
@@ -62,7 +62,6 @@ class AssetsCompressorTest extends CakeTestCase {
 		$this->assertSame($this->response, $this->Compressor->beforeDispatch($event));
 
 		$this->assertEquals('', $this->response->body());
-		$this->assertEquals(304, $this->response->statusCode());
 		$this->assertTrue($event->isStopped());
 	}
 


### PR DESCRIPTION
Given the scenario:
1. `AssetCompressor` filter attached before `AssetDispatcher`
2. `ccss` and `cjs` paths as `cachePath`
3. Dynamic build, no shell called

It will succeed the first request (no cache), however on the second request it will give a 404, thrown by `AssetDispatcher`

Instead I changed the code so `AssetCompressor` always stops propagation. Which I believe is the right thing to do, since no other Dispatcher would be able to take from there and finish the dispatching.
