### PR TITLE
dynamic build files do not work when debug > 0 and using alwaysEnableController

### DIFF
--- a/View/Helper/AssetCompressHelper.php
+++ b/View/Helper/AssetCompressHelper.php
@@ -345,7 +345,7 @@ class AssetCompressHelper extends AppHelper {
 			$path = rtrim($path, '/') . '/';
 			$route = $path . $this->_getBuildName($file);
 		}
-		if ($devMode) {
+		if ($devMode || $this->_Config->general('alwaysEnableController')) {
 			$baseUrl = str_replace(WWW_ROOT, '/', $path);
 			$route = $this->_getRoute($file, $baseUrl);
 		}


### PR DESCRIPTION
I want to always enable controller, so I have `alwaysEnableController = true`

In my view I have `$this->AssetCompress->addScript(array('Users/login.js'),'users_login.js');`

When debug > 0 everything works fine. When I flip debug to 1 users_login.js gives me a build file not found.  I think its cuz the helper is not looking for alwaysENableController for dynamic build files.

My asset_compress.ini: https://gist.github.com/4c5a9087557c5fc015bb

List of build files when debug 1 and debug 0: https://gist.github.com/e7625a93d6a123bbf463 (last edit is when debug is 0, the not working). You can see the dif where its not creating the dynamic build file.

Proposed patch fixes this
