### PR TITLE
Added method in the Helper to check if a build exists.

### DIFF
--- a/View/Helper/AssetCompressHelper.php
+++ b/View/Helper/AssetCompressHelper.php
@@ -460,6 +460,6 @@ class AssetCompressHelper extends AppHelper {
  */
 	public function exists($file) {
 		$buildFiles = $this->_Config->files($file);
-        return count($buildFiles) > 0;
+		return count($buildFiles) > 0;
 	}
 }


### PR DESCRIPTION
I needed to know if a build was defined in the ini file before "echoing" it, but I didn't find a public method in the Helper to check this, so I added a method called exists that only check is a build is defined or not in the ini file.
