### PR TITLE
Incorrect path for dynamic build when App.baseUrl is set

### DIFF
--- a/View/Helper/AssetCompressHelper.php
+++ b/View/Helper/AssetCompressHelper.php
@@ -349,7 +349,7 @@ class AssetCompressHelper extends AppHelper {
 		}
 		if ($devMode || $this->_Config->general('alwaysEnableController')) {
 			$baseUrl = str_replace(WWW_ROOT, '/', $path);
-			$route = $this->_getRoute($file, $baseUrl);
+			$route = $this->_getRoute($file, Router::url($baseUrl));
 		}
 
 		if (DS == '\\') {


### PR DESCRIPTION
I use the build in server in CakePHP 2.3. Thus my <code>App.baseUrl</code> is <code>env('SCRIPT_NAME')</code>

AssetCompress helper would render this markup:

``` html
<link rel="stylesheet" type="text/css" href="/cache_css/default.css" />
```

Which is incorrect and simply 404.

This patch wraps the helpers <code>$baseUrl</code> to bring out the <code>App.baseUrl</code>. i.e.

``` html
<link rel="stylesheet" type="text/css" href="/index.php/cache_css/default.css" />
```

I've also tested this patch in an environment with doesn't set <code>App.baseUrl</code>. So for a least in development, I cannot see any issues.
