### PR TITLE
Add PATH to the ScssFilter environment

### DIFF
--- a/Lib/Filter/ScssFilter.php
+++ b/Lib/Filter/ScssFilter.php
@@ -12,7 +12,8 @@ class ScssFilter extends AssetFilter {
 
 	protected $_settings = array(
 		'ext' => '.scss',
-		'sass' => '/usr/bin/sass'
+		'sass' => '/usr/bin/sass',
+		'path' => '/usr/bin',
 	);
 
 /**
@@ -27,7 +28,7 @@ class ScssFilter extends AssetFilter {
 			return $input;
 		}
 		$bin = $this->_settings['sass'] . ' ' . $filename;
-		$return = $this->_runCmd($bin, '');
+		$return = $this->_runCmd($bin, '', array('PATH' => $this->_settings['path']));
 		return $return;
 	}
 


### PR DESCRIPTION
This works for me as I have Ruby and Sass installed via MacPorts in <code>/opt/local/bin</code>.

Trying to help a colleague who uses RVM and struggling to find all the necessary PATH's. (Gem and Ruby found)
