### PR TITLE
Turning ClosureJs settings into command options

### DIFF
--- a/Lib/Filter/ClosureJs.php
+++ b/Lib/Filter/ClosureJs.php
@@ -35,9 +35,16 @@ class ClosureJs extends AssetFilter {
 		$jar = $this->_findExecutable(App::path('vendors'), $this->_settings['path']);
 
 		//Closure works better if you specify an input file. Also supress warnings by default
-		$tmpFile = tempnam(TMP,'CLOSURE');
+		$tmpFile = tempnam(TMP, 'CLOSURE');
 		file_put_contents($tmpFile, $input);
-		$cmd = 'java -jar "' . $jar . '" --js=' . $tmpFile . ' --warning_level=' . $this->_settings['warning_level'];
+
+		$options = array('js' => $tmpFile) + $this->_settings;
+		$options = array_diff_key($options, array('path' => null, 'paths' => null, 'target' => null));
+
+		$cmd = 'java -jar "' . $jar . '"';
+		foreach ($options as $key => $value) {
+			$cmd .= sprintf(' --%s=%s', $key, $value);
+		}
 
 		try {
 			$output = $this->_runCmd($cmd, null);

--- a/Test/Case/Lib/Filter/ClosureJsTest.php
+++ b/Test/Case/Lib/Filter/ClosureJsTest.php
@@ -1,0 +1,25 @@
+<?php
+App::uses('ClosureJs', 'AssetCompress.Filter');
+
+class ClosureJsTest extends CakeTestCase {
+	public function testCommand() {
+		$Filter = $this->getMock('ClosureJs', array('_findExecutable', '_runCmd'));
+		
+		$Filter->expects($this->at(0))
+			->method('_findExecutable')
+			->will($this->returnValue('closure/compiler.jar'));
+		$Filter->expects($this->at(1))
+			->method('_runCmd')
+			->with($this->matchesRegularExpression('/java -jar "closure\/compiler\.jar" --js=(.*)\/tmp\/CLOSURE(.*) --warning_level=QUIET/'));
+		$Filter->output('file.js', 'var a = 1;');
+
+		$Filter->expects($this->at(0))
+			->method('_findExecutable')
+			->will($this->returnValue('closure/compiler.jar'));
+		$Filter->expects($this->at(1))
+			->method('_runCmd')
+			->with($this->matchesRegularExpression('/java -jar "closure\/compiler\.jar" --js=(.*)\/tmp\/CLOSURE(.*) --warning_level=QUIET --language_in=ECMASCRIPT5/'));
+		$Filter->settings(array('language_in' => 'ECMASCRIPT5'));
+		$Filter->output('file.js', 'var a = 1;');
+	}
+}


### PR DESCRIPTION
### What

Anything passed into `settings` will become a option on the command.
### Why

I needed a different `language_in` so I could compile AngularJS, which uses EcmaScript 5.
