### PR TITLE
Add `ClosureCompiler` filter.

### DIFF
--- a/Lib/Filter/ClosureCompiler.php
+++ b/Lib/Filter/ClosureCompiler.php
@@ -25,7 +25,6 @@ class ClosureCompiler extends AssetFilter {
  * NOTE: statistics and warnings are only used when in debug mode.
  *
  * - level (string) Defaults to WHITESPACE_ONLY. Values: SIMPLE_OPTIMIZATIONS, ADVANCED_OPTIMIZATIONS.
- * - print (string) How to output the errors, statistics and/or warnings.
  * - statistics (boolean) Defaults to FALSE.
  * - warnings (mixed) Defaults to FALSE. Values: TRUE or QUIET, DEFAULT, VERBOSE.
  *


### PR DESCRIPTION
A new filter for those of us who want to use the [Google Closure compiler API](https://developers.google.com/closure/compiler/docs/api-ref). Similar to the ClosureJS filter but without having to install JAVA nor the `closure/compiler.jar`.

The compilation level can be set using the `level` key in settings like so:

```
[filter_ClosureCompiler]
level = SIMPLE_OPTIMIZATIONS
```

One can also check statistics and/or warnings (only in debug mode):

```
[filter_ClosureCompiler]
statistics = true
warnings = true
```

Furthermore, extra parameters can be passed to the API like so:

```
[filter_ClosureCompiler]
level = ADVANCED_OPTIMIZATIONS
formatting = pretty_print
externs_url = http://www.myserver.com/myexterns.js
```

That's about it! 

Hoping it is judged useful to others and gets added to the plugin's core.

Best,

Jad
