### PR TITLE
Fixing bug when there is no error, but a linefeed or more is returned as...

### DIFF
--- a/Lib/AssetFilter.php
+++ b/Lib/AssetFilter.php
@@ -94,7 +94,7 @@ class AssetFilter implements AssetFilterInterface {
 		$Process->environment($environment);
 		$Process->command($cmd)->run($content);
 
-		if (trim($Process->error())) {
+		if ($Process->error()) {
 			throw new RuntimeException($Process->error());
 		}
 		return $Process->output();

--- a/Lib/AssetProcess.php
+++ b/Lib/AssetProcess.php
@@ -86,7 +86,7 @@ class AssetProcess {
  * @return string Content from the command.
  */
 	public function error() {
-		return $this->_error;
+		return trim($this->_error);
 	}
 
 /**


### PR DESCRIPTION
When running UglifyJS filter in my Windows environment, I had a problem where the output was generated correctly, but the $Process->error() method returned two line feeds (char 10) and nothing more.

string(2)"

"

The problem occurred only with the UglifyJS filter, so I added a check to only throw the RuntimeException only when there is an error message that is not only whitespace, tabs or line feeds.
