### PR TITLE
From 2.4, the API for HtmlHelper::css() has been changed. Fixed

### DIFF
--- a/View/Helper/AssetCompressHelper.php
+++ b/View/Helper/AssetCompressHelper.php
@@ -297,14 +297,14 @@ class AssetCompressHelper extends AppHelper {
 			foreach ($buildFiles as $part) {
 				$part = $scanner->resolve($part, false);
 				$part = str_replace(DS, '/', $part);
-				$output .= $this->Html->css($part, null, $options);
+				$output .= $this->Html->css($part, $options);
 			}
 			return $output;
 		}
 
 		$url = $this->url($file, $options);
 		unset($options['full']);
-		return $this->Html->css($url, null, $options);
+		return $this->Html->css($url, $options);
 	}
 
 /**


### PR DESCRIPTION
Without this change, the options for the `css()` method will always be NULL, because from version 2.4, the method accepts only two options.
