### PR TITLE
Adjusted the separator from DS to _ to enable auto include scripts

### DIFF
--- a/View/Helper/AssetCompressHelper.php
+++ b/View/Helper/AssetCompressHelper.php
@@ -137,7 +137,7 @@ class AssetCompressHelper extends AppHelper {
 		}
 		$files = array(
 			$this->params['controller'] . '.js',
-			$this->params['controller'] . DS . $this->params['action'] . '.js'
+			$this->params['controller'] . '_' . $this->params['action'] . '.js'
 		);
 
 		foreach ($files as $file) {


### PR DESCRIPTION
As per the wiki, auto include will be looking for $controller_$action.js and presumably not $controller/$action.js that the DS would generate?
