### PR TITLE
Fallback for disabled parse_ini_file

### DIFF
--- a/Lib/AssetConfig.php
+++ b/Lib/AssetConfig.php
@@ -148,8 +148,12 @@ class AssetConfig {
 		if (empty($filename) || !is_string($filename) || !file_exists($filename)) {
 			throw new RuntimeException(sprintf('Configuration file "%s" was not found.', $filename));
 		}
-
-		return parse_ini_file($filename, true);
+		
+		if (function_exists('parse_ini_file')) {
+ 			return parse_ini_file($filename, true);
+ 		} else {
+ 			return parse_ini_string(file_get_contents($filename), true);
+ 		}
 	}
 
 /**


### PR DESCRIPTION
Usually in shared hostings parse_ini_file() will be disabled (also with exec, system, etc.).
Added fallback to keep same behavior by reading first ini file contents and running parse_ini_string() after it.
