### PR TITLE
Fix plugin script raw url in windows platforms

### DIFF
--- a/Test/Case/View/Helper/AssetCompressHelperTest.php
+++ b/Test/Case/View/Helper/AssetCompressHelperTest.php
@@ -430,6 +430,17 @@ class AssetCompressHelperTest extends CakeTestCase {
 			),
 		);
 		$this->assertTags($result, $expected);
+
+		$result = $this->Helper->script('plugins.js', array('raw' => true));
+		$expected = array(
+			array(
+				'script' => array(
+					'type' => 'text/javascript',
+					'src' => '/test_asset/plugin.js'
+				)
+			)
+		);
+		$this->assertTags($result, $expected);
 	}
 
 	public function testCompiledBuildWithThemes() {

--- a/Test/test_files/Config/plugins.ini
+++ b/Test/test_files/Config/plugins.ini
@@ -2,6 +2,9 @@
 
 [js]
 
+[plugins.js]
+files[] = plugin:TestAsset:plugin.js
+
 [css]
 
 [plugins.css]

--- a/View/Helper/AssetCompressHelper.php
+++ b/View/Helper/AssetCompressHelper.php
@@ -336,6 +336,7 @@ class AssetCompressHelper extends AppHelper {
 			$scanner = new AssetScanner($config->paths('js', $file), $this->theme);
 			foreach ($buildFiles as $part) {
 				$part = $scanner->resolve($part, false);
+				$part = str_replace(DS, '/', $part);
 				$output .= $this->Html->script($part, $options);
 			}
 			return $output;


### PR DESCRIPTION
There was a missing directory separator to slash conversion in AssetCompressHelper::script(), like the one done in css() method. This was generating wrong urls in windows platforms with encoded backslashes.
