### PR TITLE
Use Cake tmp folder instead of system tmp dir for temporal files generated by filters

### DIFF
--- a/Lib/Filter/Hogan.php
+++ b/Lib/Filter/Hogan.php
@@ -39,7 +39,7 @@ class Hogan extends AssetFilter {
 		if (substr($filename, strlen($this->_settings['ext']) * -1) !== $this->_settings['ext']) {
 			return $input;
 		}
-		$tmpfile = tempnam(sys_get_temp_dir(), 'asset_compress_hogan');
+		$tmpfile = tempnam(TMP, 'asset_compress_hogan');
 		$id = str_replace($this->_settings['ext'], '', basename($filename));
 		$this->_generateScript($tmpfile, $id, $input);
 		$bin = $this->_settings['node'] . ' ' . $tmpfile;

--- a/Lib/Filter/LessCss.php
+++ b/Lib/Filter/LessCss.php
@@ -28,7 +28,7 @@ class LessCss extends AssetFilter {
 			return $input;
 		}
 
-		$tmpfile = tempnam(sys_get_temp_dir(), 'asset_compress_less');
+		$tmpfile = tempnam(TMP, 'asset_compress_less');
 		$this->_generateScript($tmpfile, $input);
 
 		$bin = $this->_settings['node'] . ' ' . $tmpfile;


### PR DESCRIPTION
Some filters generate temporal files to system tmp dir, and in some hosts access to this folder is usually disabled via open_basedir. Thus, using Cake's TMP folder avoids this issue.
