### PR TITLE
allow custom filter classes in custom locations

### DIFF
--- a/Lib/AssetFilterCollection.php
+++ b/Lib/AssetFilterCollection.php
@@ -31,9 +31,11 @@ class AssetFilterCollection {
 	protected function _buildFilters($filters, $settings) {
 		foreach ($filters as $className) {
 			list($plugin, $className) = pluginSplit($className, true);
-			App::uses($className, 'AssetCompress.Lib/Filter');
 			if (!class_exists($className)) {
-				App::uses($className, $plugin . 'AssetCompress/Filter');
+				App::uses($className, 'AssetCompress.Lib/Filter');
+				if (!class_exists($className)) {
+					App::uses($className, $plugin . 'AssetCompress/Filter');
+				}
 			}
 			if (!class_exists($className)) {
 				throw new Exception(sprintf('Cannot not load filter "%s".', $plugin . $className));


### PR DESCRIPTION
Only add class path using app::uses when class is not available.

So I can App::uses('CustomFilter', 'Lib'); in bootstrap.php without it being overwritten by the _buildFilters method.
