### PR TITLE
Only write build file times to cache after the build is complete.

### DIFF
--- a/Console/Command/Task/AssetBuildTask.php
+++ b/Console/Command/Task/AssetBuildTask.php
@@ -262,14 +262,16 @@ class AssetBuildTask extends AppShell {
 			$this->out('<info>Skip building</info> ' . $name . ' existing file is still fresh.');
 			return;
 		}
-		// Clear the timestamp so it can be regenerated.
-		$this->Cacher->setTimestamp($build, 0);
-
+		
+		$time = time();
+		$this->Cacher->setTimestamp($build, $time);
+		
 		$name = $this->Cacher->buildFileName($build);
 		try {
 			$this->out('<success>Saving file</success> for ' . $name);
 			$contents = $this->Compiler->generate($build);
 			$this->Cacher->write($build, $contents);
+			$this->Cacher->setTimestamp($build, $time, true);
 		} catch (Exception $e) {
 			$this->err('Error: ' . $e->getMessage());
 		}

--- a/Lib/AssetCache.php
+++ b/Lib/AssetCache.php
@@ -118,16 +118,21 @@ class AssetCache {
  *
  * @param string $build The name of the build to set a timestamp for.
  * @param integer $time The timestamp.
+ * @param boolean $buildComplete Has the build successfully completed?
  * @return void
  */
-	public function setTimestamp($build, $time) {
+	public function setTimestamp($build, $time, $buildComplete = false) {
 		$ext = $this->_Config->getExt($build);
 		if (!$this->_Config->get($ext . '.timestamp')) {
 			return false;
 		}
 		$data = $this->_readTimestamp();
 		$build = $this->buildFileName($build, false);
-		$data[$build] = $time;
+		$name = $buildComplete ? $build : '~' . $build;
+		$data[$name] = $time;
+		if ($buildComplete && isset($data['~' . $build])) {
+			unset($data['~' . $build]);
+		}
 		if ($this->_Config->general('cacheConfig')) {
 			Cache::write(AssetConfig::CACHE_BUILD_TIME_KEY, $data, AssetConfig::CACHE_CONFIG);
 		}
@@ -154,6 +159,9 @@ class AssetCache {
 		}
 		$data = $this->_readTimestamp();
 		$name = $this->buildFileName($build, false);
+		if (isset($data['~' . $name])) {
+			return $data['~' . $name];
+		}
 		if (!empty($data[$name])) {
 			return $data[$name];
 		}


### PR DESCRIPTION
I was having problems with the build timestamp cache being overwritten before the build was completed. This caused problems when building on the live site as it could take a few seconds to build which made my CDN cache the 404 error page.
