### PR TITLE
Add alwaysAllowBuildFiles config var to always enable build files in dev...

### DIFF
--- a/Config/asset_compress.sample.ini
+++ b/Config/asset_compress.sample.ini
@@ -9,9 +9,13 @@
 ;   resources repeatedly. However, if you need the controller available
 ;   in production. You can enable this flag.
 ;
+; * alwaysAllowBuildFiles - Set to true to always enable the
+;   build files in development mode.
+;
 [General]
 cacheConfig = false
 alwaysEnableController = false
+alwaysAllowBuildFiles = false
 
 ; Define an extension type.
 ;

--- a/View/Helper/AssetCompressHelper.php
+++ b/View/Helper/AssetCompressHelper.php
@@ -381,12 +381,13 @@ class AssetCompressHelper extends AppHelper {
 			return $baseUrl . $this->_getBuildName($file);
 		}
 
-		if (!$devMode) {
+		$allow_build = $config->general('alwaysAllowBuildFiles');
+		$enable_ctrl = $config->general('alwaysEnableController');
+		if ((!$devMode && !$enable_ctrl) || ($devMode && $allow_build)) {
 			$path = str_replace(WWW_ROOT, '/', $path);
 			$path = rtrim($path, '/') . '/';
 			$route = $path . $this->_getBuildName($file);
-		}
-		if ($devMode || $config->general('alwaysEnableController')) {
+		} else {
 			$baseUrl = str_replace(WWW_ROOT, '/', $path);
 			$route = $this->_getRoute($file, $baseUrl);
 		}


### PR DESCRIPTION
Hi Mark. 
Here is a quick change to allow build files to be used in development mode. The rationale here is that I usually have a third_party target that includes CSS files from third-party libraries that are _not_ likely to change very often (say, Font Awesome, jQuery UI, etc). Having the controller regenerate that target in development mode takes time/resources, I'd rather serve the build file. My own JS/CSS development files, which are likely to change a lot more often, are in a different target, created by the Asset Helper with the 'raw' option set to true in dev mode. TLDR; in dev mode I end up with one link rel="stylesheet" serving all third party CSS, then one link per application-specific css file. In production mode, this automatically defaults to all targets being build files (I.e. only two links). This scenario used to work with the 1.3 version of that plugin. I'm upgrading CakePHP to 2.x, and upgraded that plugin as well; it no longer works. This option brings that "feature" back. 
Thanks
