### PR TITLE
Dont use the deprecated way for css() anymore.

### DIFF
--- a/View/Helper/AssetCompressHelper.php
+++ b/View/Helper/AssetCompressHelper.php
@@ -297,7 +297,7 @@ class AssetCompressHelper extends AppHelper {
 			foreach ($buildFiles as $part) {
 				$part = $scanner->find($part, false);
 				$part = str_replace(DS, '/', $part);
-				$output .= $this->Html->css($part, null, $options);
+				$output .= $this->Html->css($part, $options);
 			}
 			return $output;
 		}


### PR DESCRIPTION
Since CakePHP 2.4 this should not be done like this anymore.