### PR TITLE
Use realpath when clearing cache files

### DIFF
--- a/Console/Command/AssetCompressShell.php
+++ b/Console/Command/AssetCompressShell.php
@@ -149,9 +149,12 @@ class AssetCompressShell extends AppShell {
 				}
 			}
 			if (in_array($base, $targets)) {
-				$this->out(' - Deleting ' . $path . $name);
-				unlink($path . $name);
-				continue;
+				$filepath = realpath($path . DS . $name);
+				if (!$filepath) {
+					continue;
+				}
+				$this->out(' - Deleting ' . $filepath);
+				unlink($filepath);
 			}
 		}
 	}


### PR DESCRIPTION
Clearing temporary files in app/tmp would result in error messages because of missing separators.
Using realpath we also automatically check for the file to exist.

```
 - Deleting /home/alex/Webdev/project/app/tmp/cache/asset_compressapp.css
Warning Error: unlink(/home/alex/Webdev/project/app/tmp/cache/asset_compressapp.css): No such file or directory in [/home/alex/Webdev/project/app/Plugin/AssetCompress/Console/Command/AssetCompressShell.php, line 153]
```
