### PR TITLE
Config timestamp

### DIFF
--- a/src/AssetConfig.php
+++ b/src/AssetConfig.php
@@ -57,6 +57,13 @@ class AssetConfig
     );
 
     /**
+     * The max modified time of all the config files loaded.
+     *
+     * @var int
+     */
+    protected $_modifiedTime = 0;
+
+    /**
      * A hash of constants that can be expanded when reading ini files.
      *
      * @var array
@@ -151,6 +158,7 @@ class AssetConfig
         if (empty($filename) || !is_string($filename) || !file_exists($filename)) {
             throw new RuntimeException(sprintf('Configuration file "%s" was not found.', $filename));
         }
+        $this->_modifiedTime = max($this->_modifiedTime, filemtime($filename));
 
         if (function_exists('parse_ini_file')) {
             return parse_ini_file($filename, true);
@@ -501,5 +509,15 @@ class AssetConfig
     public function extensions()
     {
         return ['css', 'js'];
+    }
+
+    /**
+     * Get the modified time of the loaded configuration files.
+     *
+     * @return int
+     */
+    public function modifiedTime()
+    {
+        return $this->_modifiedTime;
     }
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -59,7 +59,9 @@ class Factory
             'js' => $this->config->get('js.timestamp'),
             'css' => $this->config->get('css.timestamp'),
         ];
-        return new AssetWriter($timestamp, TMP, $this->config->theme());
+        $writer = new AssetWriter($timestamp, TMP, $this->config->theme());
+        $writer->configTimestamp($this->config->modifiedTime());
+        return $writer;
     }
 
     /**
@@ -69,10 +71,12 @@ class Factory
      */
     public function cacher()
     {
-        return new AssetCacher(
+        $cache = new AssetCacher(
             CACHE . 'asset_compress' . DS,
             $this->config->theme()
         );
+        $cache->configTimestamp($this->config->modifiedTime());
+        return $cache;
     }
 
     /**

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -1,15 +1,15 @@
 <?php
 namespace AssetCompress;
 
-use AssetCompress\AssetCacher;
-use AssetCompress\AssetConfig;
 use AssetCompress\AssetCollection;
 use AssetCompress\AssetCompiler;
+use AssetCompress\AssetConfig;
 use AssetCompress\AssetTarget;
-use AssetCompress\AssetWriter;
-use AssetCompress\Filter\FilterRegistry;
-use AssetCompress\File\Remote;
 use AssetCompress\File\Local;
+use AssetCompress\File\Remote;
+use AssetCompress\Filter\FilterRegistry;
+use AssetCompress\Output\AssetCacher;
+use AssetCompress\Output\AssetWriter;
 use Cake\Core\App;
 use RuntimeException;
 

--- a/src/Output/AssetCacher.php
+++ b/src/Output/AssetCacher.php
@@ -1,5 +1,5 @@
 <?php
-namespace AssetCompress;
+namespace AssetCompress\Output;
 
 use AssetCompress\AssetTarget;
 use Cake\Filesystem\Folder;

--- a/src/Output/AssetWriter.php
+++ b/src/Output/AssetWriter.php
@@ -2,6 +2,7 @@
 namespace AssetCompress\Output;
 
 use AssetCompress\AssetTarget;
+use AssetCompress\Output\FreshTrait;
 use RuntimeException;
 
 /**
@@ -10,6 +11,8 @@ use RuntimeException;
  */
 class AssetWriter
 {
+    use FreshTrait;
+
     const BUILD_TIME_FILE = 'asset_compress_build_time';
 
     protected $timestamp = [];
@@ -72,33 +75,6 @@ class AssetWriter
         $success = file_put_contents($path . DS . $filename, $content) !== false;
         $this->finalize($build);
         return $success;
-    }
-
-    /**
-     * Check to see if a cached build file is 'fresh'.
-     * Fresh cached files have timestamps newer than all of the component
-     * files.
-     *
-     * @param AssetTarget $target The target file being built.
-     * @return boolean
-     */
-    public function isFresh(AssetTarget $target)
-    {
-        $buildName = $this->buildFileName($target);
-        $buildFile = $target->outputDir() . DS . $buildName;
-
-        if (!file_exists($buildFile)) {
-            return false;
-        }
-        $buildTime = filemtime($buildFile);
-
-        foreach ($target->files() as $file) {
-            $time = $file->modifiedTime();
-            if ($time === false || $time >= $buildTime) {
-                return false;
-            }
-        }
-        return true;
     }
 
     /**

--- a/src/Output/AssetWriter.php
+++ b/src/Output/AssetWriter.php
@@ -1,5 +1,5 @@
 <?php
-namespace AssetCompress;
+namespace AssetCompress\Output;
 
 use AssetCompress\AssetTarget;
 use RuntimeException;

--- a/src/Output/FreshTrait.php
+++ b/src/Output/FreshTrait.php
@@ -1,0 +1,57 @@
+<?php
+namespace AssetCompress\Output;
+
+use AssetCompress\AssetTarget;
+
+trait FreshTrait
+{
+    protected $configTime = 0;
+
+    /**
+     * Set the modified time of the configuration
+     * files.
+     *
+     * This value is used to determine if a build
+     * output is still 'fresh'.
+     *
+     * @param int $time The timestamp the configuration files 
+     *  were modified at.
+     * @return void
+     */
+    public function configTimestamp($time)
+    {
+        $this->configTime = $time;
+    }
+
+    /**
+     * Check to see if a cached build file is 'fresh'.
+     * Fresh cached files have timestamps newer than all of the component
+     * files.
+     *
+     * @param AssetTarget $target The target file being built.
+     * @return boolean
+     */
+    public function isFresh(AssetTarget $target)
+    {
+        $buildName = $this->buildFileName($target);
+        $buildFile = $target->outputDir() . DS . $buildName;
+
+        if (!file_exists($buildFile)) {
+            return false;
+        }
+        $buildTime = filemtime($buildFile);
+
+        if ($this->configTime && $this->configTime >= $buildTime) {
+            return false;
+        }
+
+        foreach ($target->files() as $file) {
+            $time = $file->modifiedTime();
+            if ($time === false || $time >= $buildTime) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+}

--- a/src/Routing/Filter/AssetCompressorFilter.php
+++ b/src/Routing/Filter/AssetCompressorFilter.php
@@ -1,9 +1,7 @@
 <?php
 namespace AssetCompress\Routing\Filter;
 
-use AssetCompress\AssetCompiler;
 use AssetCompress\Config\ConfigFinder;
-use AssetCompress\AssetWriter;
 use AssetCompress\Factory;
 use Cake\Core\Configure;
 use Cake\Event\Event;

--- a/tests/TestCase/AssetConfigTest.php
+++ b/tests/TestCase/AssetConfigTest.php
@@ -32,6 +32,16 @@ class AssetConfigTest extends TestCase
         $config = AssetConfig::buildFromIniFile($this->testConfig);
         $this->assertEquals(1, $config->get('js.timestamp'));
         $this->assertEquals(1, $config->general('writeCache'));
+        $this->assertEquals(filemtime($this->testConfig), $config->modifiedTime());
+    }
+
+    public function testLoadUpdatesModifiedTime()
+    {
+        $config = AssetConfig::buildFromIniFile($this->testConfig);
+        $this->assertEquals(filemtime($this->testConfig), $config->modifiedTime());
+
+        $config->load($this->_themeConfig);
+        $this->assertEquals(filemtime($this->_themeConfig), $config->modifiedTime());
     }
 
     public function testExceptionOnBogusFile()

--- a/tests/TestCase/Output/AssetCacherTest.php
+++ b/tests/TestCase/Output/AssetCacherTest.php
@@ -27,6 +27,15 @@ class AssetCacherTest extends TestCase
         $this->themed = new AssetCacher(TMP, 'Modern');
     }
 
+    public function tearDown()
+    {
+        parent::tearDown();
+        $path = TMP . 'Modern-template.js';
+        if (file_exists($path)) {
+            unlink($path);
+        }
+    }
+
     public function testBuildFileName()
     {
         $result = $this->cacher->buildFileName($this->target);
@@ -76,4 +85,10 @@ class AssetCacherTest extends TestCase
         $this->assertFalse($this->themed->isFresh($this->target));
     }
 
+    public function testIsFreshConfigOld()
+    {
+        file_put_contents(TMP . 'Modern-template.js', 'contents');
+        $this->themed->configTimestamp(time() + 10);
+        $this->assertFalse($this->themed->isFresh($this->target));
+    }
 }

--- a/tests/TestCase/Output/AssetCacherTest.php
+++ b/tests/TestCase/Output/AssetCacherTest.php
@@ -1,7 +1,7 @@
 <?php
-namespace AssetCompress\Test\TestCase;
+namespace AssetCompress\Test\TestCase\Output;
 
-use AssetCompress\AssetCacher;
+use AssetCompress\Output\AssetCacher;
 use AssetCompress\AssetTarget;
 use AssetCompress\File\Local;
 use Cake\TestSuite\TestCase;

--- a/tests/TestCase/Output/AssetWriterTest.php
+++ b/tests/TestCase/Output/AssetWriterTest.php
@@ -1,7 +1,7 @@
 <?php
-namespace AssetCompress\Test\TestCase;
+namespace AssetCompress\Test\TestCase\Output;
 
-use AssetCompress\AssetWriter;
+use AssetCompress\Output\AssetWriter;
 use AssetCompress\AssetTarget;
 use AssetCompress\File\Local;
 use Cake\TestSuite\TestCase;

--- a/tests/TestCase/Output/AssetWriterTest.php
+++ b/tests/TestCase/Output/AssetWriterTest.php
@@ -56,6 +56,14 @@ class AssetWriterTest extends TestCase
         unlink(TMP . '/test.js');
     }
 
+    public function testIsFreshConfigOld()
+    {
+        file_put_contents(TMP . '/test.js', 'contents');
+        $this->writer->configTimestamp(time() + 10);
+        $this->assertFalse($this->writer->isFresh($this->target));
+        unlink(TMP . '/test.js');
+    }
+
     public function testThemeFileSaving()
     {
         $writer = new AssetWriter(['js' => false, 'css' => false], TMP, 'blue');


### PR DESCRIPTION
Record the max timestamp of all loaded configuration files. This allows build outputs to be invalided when the configuration file is updated. This is helpful when the configuration files add old files into a target, or a file is removed from a target.