### PR TITLE
Use Configure iniFile setting for a different location.

### DIFF
--- a/Routing/Filter/AssetCompressor.php
+++ b/Routing/Filter/AssetCompressor.php
@@ -115,7 +115,8 @@ class AssetCompressor extends DispatcherFilter {
  */
 	protected function _getConfig() {
 		if (empty($this->_Config)) {
-			$this->_Config = AssetConfig::buildFromIniFile();
+			$settings = (array)Configure::read('AssetCompress');
+			$this->_Config = AssetConfig::buildFromIniFile(!empty($settings['iniFile']) ? $settings['iniFile'] : null);
 		}
 		return $this->_Config;
 	}

--- a/View/Helper/AssetCompressHelper.php
+++ b/View/Helper/AssetCompressHelper.php
@@ -70,8 +70,9 @@ class AssetCompressHelper extends AppHelper {
  * @return void
  */
 	public function __construct(View $View, $settings = array()) {
+		$settings += (array)Configure::read('AssetCompress');
 		if (empty($settings['noconfig'])) {
-			$config = AssetConfig::buildFromIniFile();
+			$config = AssetConfig::buildFromIniFile(!empty($settings['iniFile']) ? $settings['iniFile'] : null);
 			$this->config($config);
 		}
 		parent::__construct($View, $settings);


### PR DESCRIPTION
buildFromIniFile() supports a different file path, but those settings can not be passed in currently from the helper or the dispatching filter.
This resolves it cleanly and DRY using a joined Configure setting `AssetCompress.iniFile` to overwrite the

```php
if (empty($iniFile)) {
	$iniFile = APP . 'Config' . DS . 'asset_compress.ini';
}
```
part.