### PR TITLE
Fix the asset path for windows

### DIFF
--- a/src/View/Helper/AssetCompressHelper.php
+++ b/src/View/Helper/AssetCompressHelper.php
@@ -395,9 +395,7 @@ class AssetCompressHelper extends Helper
             $query['theme'] = $this->theme;
         }
 
-        if (substr($base, -1) !== DS && DS !== '\\') {
-            $base .= '/';
-        }
+        $base = rtrim($base, '/') . '/';
         $query = empty($query) ? '' : '?' . http_build_query($query);
         return $base . $file->name() . $query;
     }


### PR DESCRIPTION
I don't know how previous solution should be working on Windows, because the condition was never adding the slash on the Windows (since `DS !== '\\'` was always false on Wins).

My change fixed the #247.

Refs #247 