### PR TITLE
Filter cache busting

### DIFF
--- a/src/AssetFilter.php
+++ b/src/AssetFilter.php
@@ -2,6 +2,7 @@
 namespace AssetCompress;
 
 use AssetCompress\AssetProcess;
+use AssetCompress\AssetTarget;
 use AssetCompress\AssetFilterInterface;
 use RuntimeException;
 
@@ -53,6 +54,20 @@ class AssetFilter implements AssetFilterInterface
     public function output($target, $content)
     {
         return $content;
+    }
+
+    /**
+     * Overloaded in filters that are pre-processors.
+     *
+     * Preprocessor filters can use this hook method to find a list of dependent
+     * files.
+     *
+     * @param AssetTarget $target The target to find dependencies for this filter.
+     * @return array An array of AssetCompress\File\Local objects.
+     */
+    public function getDependencies(AssetTarget $file)
+    {
+        return [];
     }
 
     /**

--- a/src/AssetFilterInterface.php
+++ b/src/AssetFilterInterface.php
@@ -34,4 +34,15 @@ interface AssetFilterInterface
      * @return array Updated Settings.
      */
     public function settings(array $settings = null);
+
+    /**
+     * Find any additional filter based dependencies.
+     *
+     * Preprocessor filters can use this hook method to find a list of dependent
+     * files. For example, `import` statements in Less/Sass.
+     *
+     * @param AssetTarget $target The target to find dependencies for this filter.
+     * @return array An array of AssetCompress\File\Local objects.
+     */
+    public function getDependencies(AssetTarget $target);
 }

--- a/src/Filter/CssDependencyTrait.php
+++ b/src/Filter/CssDependencyTrait.php
@@ -1,0 +1,67 @@
+<?php
+namespace AssetCompress\Filter;
+
+use AssetCompress\AssetTarget;
+use AssetCompress\File\Local;
+use AssetCompress\Utility\CssUtils;
+
+trait CssDependencyTrait
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getDependencies(AssetTarget $target)
+    {
+        $children = [];
+        foreach ($target->files() as $file) {
+            $imports = CssUtils::extractImports($file->contents());
+            if (empty($imports)) {
+                continue;
+            }
+
+            $ext = $this->_settings['ext'];
+            $extLength = strlen($ext);
+
+            $deps = [];
+            foreach ($imports as $name) {
+                if ('.css' === substr($name, -4)) {
+                    // skip normal css imports
+                    continue;
+                }
+                if ($ext !== substr($name, -$extLength)) {
+                    $name .= $ext;
+                }
+                $deps[] = $name;
+            }
+            foreach ($deps as $import) {
+                $path = $this->_findFile($import);
+                $file = new Local($path);
+                $newTarget = new AssetTarget('phony.css', [$file]);
+
+                $children[] = $file;
+                // Only recurse through non-css imports as css files are not
+                // inlined by less/sass.
+                if ($ext === substr($import, -$extLength)) {
+                    $children = array_merge($children, $this->getDependencies($newTarget));
+                }
+            }
+        }
+        return $children;
+    }
+
+    /**
+     * Attempt to locate a file in the configured paths.
+     *
+     * @param string $file The file to find.
+     * @return string The resolved file.
+     */
+    protected function _findFile($file)
+    {
+        foreach ($this->_settings['paths'] as $path) {
+            if (file_exists($path . $file)) {
+                return $path . $file;
+            }
+        }
+        return $file;
+    }
+}

--- a/src/Filter/LessCss.php
+++ b/src/Filter/LessCss.php
@@ -16,7 +16,8 @@ class LessCss extends AssetFilter
     protected $_settings = array(
         'ext' => '.less',
         'node' => '/usr/local/bin/node',
-        'node_path' => '/usr/local/lib/node_modules'
+        'node_path' => '/usr/local/lib/node_modules',
+        'paths' => [],
     );
 
     /**
@@ -50,12 +51,12 @@ var less = require('less'),
 
 var parser = new less.Parser({ paths: %s });
 parser.parse(%s, function (e, tree) {
-	if (e) {
-		less.writeError(e);
-		process.exit(1)
-	}	
-	util.print(tree.toCSS());
-	process.exit(0);
+    if (e) {
+        less.writeError(e);
+        process.exit(1)
+    }
+    util.print(tree.toCSS());
+    process.exit(0);
 });
 JS;
         file_put_contents($file, sprintf($text, str_replace('\/*', '', json_encode($this->_settings['paths'])), json_encode($input)));

--- a/src/Filter/LessCss.php
+++ b/src/Filter/LessCss.php
@@ -105,7 +105,7 @@ class LessCss extends AssetFilter
     {
         $text = <<<JS
 var less = require('less'),
-	util = require('util');
+    util = require('util');
 
 var parser = new less.Parser({ paths: %s });
 parser.parse(%s, function (e, tree) {

--- a/src/Filter/LessCss.php
+++ b/src/Filter/LessCss.php
@@ -1,7 +1,10 @@
 <?php
 namespace AssetCompress\Filter;
 
+use AssetCompress\AssetTarget;
+use AssetCompress\File\Local;
 use AssetCompress\AssetFilter;
+use AssetCompress\Utility\CssUtils;
 
 /**
  * Pre-processing filter that adds support for LESS.css files.
@@ -19,6 +22,61 @@ class LessCss extends AssetFilter
         'node_path' => '/usr/local/lib/node_modules',
         'paths' => [],
     );
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDependencies(AssetTarget $target)
+    {
+        $children = [];
+        foreach ($target->files() as $file) {
+            $imports = CssUtils::extractImports($file->contents());
+            if (empty($imports)) {
+                continue;
+            }
+
+            $lessFiles = [];
+            foreach ($imports as $name) {
+                if ('.css' === substr($name, -4)) {
+                    // skip normal css imports
+                    continue;
+                }
+                if ('.less' !== substr($name, -5)) {
+                    $name .= '.less';
+                }
+                $lessFiles[] = $name;
+            }
+            foreach ($lessFiles as $import) {
+                $path = $this->_findFile($import);
+                $file = new Local($path);
+                $newTarget = new AssetTarget('phony.css', [$file]);
+
+                $children[] = $file;
+                // Only recurse through less imports as css files are not
+                // inlined by less.
+                if ('.less' === substr($import, -5)) {
+                    $children = array_merge($children, $this->getDependencies($newTarget));
+                }
+            }
+        }
+        return $children;
+    }
+
+    /**
+     * Attempt to locate a file in the configured paths.
+     *
+     * @param string $file The file to find.
+     * @return string The resolved file.
+     */
+    protected function _findFile($file)
+    {
+        foreach ($this->_settings['paths'] as $path) {
+            if (file_exists($path . $file)) {
+                return $path . $file;
+            }
+        }
+        return $file;
+    }
 
     /**
      * Runs `lessc` against any files that match the configured extension.

--- a/src/Filter/LessCss.php
+++ b/src/Filter/LessCss.php
@@ -1,7 +1,6 @@
 <?php
 namespace AssetCompress\Filter;
 
-use AssetCompress\AssetTarget;
 use AssetCompress\Filter\CssDependencyTrait;
 use AssetCompress\AssetFilter;
 

--- a/src/Filter/LessPHP.php
+++ b/src/Filter/LessPHP.php
@@ -1,9 +1,9 @@
 <?php
 namespace AssetCompress\Filter;
 
-use lessc;
-
 use AssetCompress\AssetFilter;
+use AssetCompress\Filter\CssDependencyTrait;
+use lessc;
 
 /**
  * Pre-processing filter that adds support for LESS.css files.
@@ -14,9 +14,11 @@ use AssetCompress\AssetFilter;
  */
 class LessPHP extends AssetFilter
 {
+    use CssDependencyTrait;
 
     protected $_settings = array(
         'ext' => '.less',
+        'paths' => [],
     );
 
     /**

--- a/src/Filter/LessPHP.php
+++ b/src/Filter/LessPHP.php
@@ -33,7 +33,7 @@ class LessPHP extends AssetFilter
             return $input;
         }
         if (!class_exists('lessc')) {
-            throw new \Exception(sprintf('Cannot not load filter class "%s".', 'lessc'));
+            throw new \Exception('Cannot not load "lessc" class. Make sure it is installed.');
         }
         $lc = new lessc($filename);
         return $lc->parse();

--- a/src/Filter/ScssFilter.php
+++ b/src/Filter/ScssFilter.php
@@ -2,6 +2,7 @@
 namespace AssetCompress\Filter;
 
 use AssetCompress\AssetFilter;
+use AssetCompress\Filter\CssDependencyTrait;
 
 /**
  * Pre-processing filter that adds support for SCSS files.
@@ -12,11 +13,13 @@ use AssetCompress\AssetFilter;
  */
 class ScssFilter extends AssetFilter
 {
+    use CssDependencyTrait;
 
     protected $_settings = array(
         'ext' => '.scss',
         'sass' => '/usr/bin/sass',
         'path' => '/usr/bin',
+        'paths' => [],
     );
 
     /**

--- a/src/Filter/ScssPHP.php
+++ b/src/Filter/ScssPHP.php
@@ -1,6 +1,7 @@
 <?php
 namespace AssetCompress\Filter;
 
+use AssetCompress\Filter\CssDependencyTrait;
 use scssc;
 
 use AssetCompress\AssetFilter;
@@ -14,6 +15,7 @@ use AssetCompress\AssetFilter;
  */
 class ScssPHP extends AssetFilter
 {
+    use CssDependencyTrait;
 
     protected $_settings = array(
         'ext' => '.scss',

--- a/src/Output/FreshTrait.php
+++ b/src/Output/FreshTrait.php
@@ -51,6 +51,16 @@ trait FreshTrait
                 return false;
             }
         }
+
+        foreach ($target->filterNames() as $filterName) {
+            $filter = $this->_filterRegistry->get($filterName);
+            foreach ($filter->getDependencies($target) as $child) {
+                $time = $child->modifiedTime();
+                if ($time >= $buildTime) {
+                    return false;
+                }
+            }
+        }
         return true;
     }
 

--- a/src/Utility/CssUtils.php
+++ b/src/Utility/CssUtils.php
@@ -1,0 +1,30 @@
+<?php
+namespace AssetCompress\Utility;
+
+/**
+ * Utility class for CSS files.
+ */
+class CssUtils
+{
+    const IMPORT_PATTERN = '/^\s*@import\s*(?:(?:([\'"])([^\'"]+)\\1)|(?:url\(([\'"])([^\'"]+)\\3\)));/m';
+
+    /**
+     * Extract the urls in import directives.
+     *
+     * @param string $css The CSS to parse.
+     * @return array An array of CSS files that were used in imports.
+     */
+    public static function extractImports($css)
+    {
+        $imports = [];
+        preg_match_all(static::IMPORT_PATTERN, $css, $matches, PREG_SET_ORDER);
+        if (empty($matches)) {
+            return $imports;
+        }
+        foreach ($matches as $match) {
+            $url = empty($matches[2]) ? $match[4] : $match[2];
+            $imports[] = $url;
+        }
+        return $imports;
+    }
+}

--- a/src/Utility/CssUtils.php
+++ b/src/Utility/CssUtils.php
@@ -22,7 +22,7 @@ class CssUtils
             return $imports;
         }
         foreach ($matches as $match) {
-            $url = empty($matches[2]) ? $match[4] : $match[2];
+            $url = empty($match[2]) ? $match[4] : $match[2];
             $imports[] = $url;
         }
         return $imports;

--- a/tests/TestCase/AssetCompilerTest.php
+++ b/tests/TestCase/AssetCompilerTest.php
@@ -93,8 +93,11 @@ TEXT;
         $compiler = $this->instance();
         $result = $compiler->generate($target);
         $expected = <<<TEXT
-#footer
+@import 'base';
+@import 'nav.css';
+#footer {
     color: blue;
+}
 
 @import url("reset/reset.css");
 #nav {

--- a/tests/TestCase/Filter/LessCssTest.php
+++ b/tests/TestCase/Filter/LessCssTest.php
@@ -1,0 +1,35 @@
+<?php
+namespace AssetCompress\Test\TestCase\Filter;
+
+use AssetCompress\AssetTarget;
+use AssetCompress\File\Local;
+use AssetCompress\Filter\LessCss;
+use Cake\Core\Plugin;
+use PHPUnit_Framework_TestCase;
+
+class LessCssTest extends PHPUnit_Framework_TestCase
+{
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->_cssDir = APP . 'css' . DS;
+        $this->filter = new LessCss();
+        $this->filter->settings([
+            'paths' => [$this->_cssDir]
+        ]);
+    }
+
+    public function testGetDependencies()
+    {
+        $files = [
+            new Local($this->_cssDir . 'other.less')
+        ];
+        $target = new AssetTarget('test.css', $files);
+        $result = $this->filter->getDependencies($target);
+
+        $this->assertCount(2, $result);
+        $this->assertEquals('base.less', $result[0]->name());
+        $this->assertEquals('colors.less', $result[1]->name());
+    }
+}

--- a/tests/TestCase/Filter/ScssFilterTest.php
+++ b/tests/TestCase/Filter/ScssFilterTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace AssetCompress\Test\TestCase\Filter;
 
+use AssetCompress\AssetTarget;
+use AssetCompress\File\Local;
 use AssetCompress\Filter\ScssFilter;
 use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
@@ -13,6 +15,9 @@ class ScssFilterTest extends TestCase
         parent::setUp();
         $this->_cssDir = APP . 'css' . DS;
         $this->filter = new ScssFilter();
+        $this->filter->settings([
+            'paths' => [$this->_cssDir]
+        ]);
     }
 
     public function testParsing()
@@ -26,5 +31,17 @@ class ScssFilterTest extends TestCase
         $result = $this->filter->input($this->_cssDir . 'test.scss', $content);
         $expected = file_get_contents($this->_cssDir . 'compiled_scss.css');
         $this->assertEquals($expected, $result);
+    }
+
+    public function testGetDependencies()
+    {
+        $files = [
+            new Local($this->_cssDir . 'test.scss')
+        ];
+        $target = new AssetTarget('test.css', $files);
+        $result = $this->filter->getDependencies($target);
+
+        $this->assertCount(1, $result);
+        $this->assertEquals('colors.scss', $result[0]->name());
     }
 }

--- a/tests/TestCase/Filter/SprocketsTest.php
+++ b/tests/TestCase/Filter/SprocketsTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace AssetCompress\Test\TestCase\Filter;
 
+use AssetCompress\AssetTarget;
+use AssetCompress\File\Local;
 use AssetCompress\Filter\Sprockets;
 use Cake\Core\App;
 use Cake\Core\Plugin;
@@ -182,5 +184,22 @@ var DoubleInclusion = new Class({
 
 TEXT;
         $this->assertTextEquals($expected, $result);
+    }
+
+    /**
+     * Test that getDependencies() grabs all files in the include tree.
+     *
+     * @return void
+     */
+    public function testGetDependencies()
+    {
+        $files = [
+            new Local($this->_jsDir . 'classes/nested_class.js')
+        ];
+        $target = new AssetTarget('test.js', $files);
+        $result = $this->filter->getDependencies($target);
+        $this->assertCount(2, $result, 'Should find 2 files.');
+        $this->assertEquals('base_class_two.js', $result[0]->name());
+        $this->assertEquals('base_class.js', $result[1]->name());
     }
 }

--- a/tests/TestCase/Utility/CssUtilsTest.php
+++ b/tests/TestCase/Utility/CssUtilsTest.php
@@ -1,0 +1,32 @@
+<?php
+namespace AssetCompress\Test\TestCase\Utility;
+
+use AssetCompress\Utility\CssUtils;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * Tests for CssUtils
+ */
+class CssUtilsTest extends PHPUnit_Framework_TestCase
+{
+    public function testExtractImports()
+    {
+        $css = <<<CSS
+@import     'first.css';
+@import 'second.css';
+@import "third.css";
+@import '../../relative-path.css';
+@import "http://example.com/dir/absolute-path.css";
+CSS;
+        $result = CssUtils::extractImports($css);
+        $this->assertCount(5, $result);
+        $expected = [
+            'first.css',
+            'second.css',
+            'third.css',
+            '../../relative-path.css',
+            'http://example.com/dir/absolute-path.css'
+        ];
+        $this->assertEquals($expected, $result);
+    }
+}

--- a/tests/test_files/css/base.less
+++ b/tests/test_files/css/base.less
@@ -1,0 +1,2 @@
+// Some base styles could go here.
+@import 'colors';

--- a/tests/test_files/css/colors.less
+++ b/tests/test_files/css/colors.less
@@ -1,0 +1,1 @@
+@link-color: #f00;

--- a/tests/test_files/css/colors.scss
+++ b/tests/test_files/css/colors.scss
@@ -1,0 +1,2 @@
+$blue: #3bbfce;
+$margin: 16px;

--- a/tests/test_files/css/other.less
+++ b/tests/test_files/css/other.less
@@ -1,2 +1,5 @@
-#footer
+@import 'base';
+@import 'nav.css';
+#footer {
     color: blue;
+}

--- a/tests/test_files/css/test.scss
+++ b/tests/test_files/css/test.scss
@@ -1,5 +1,4 @@
-$blue: #3bbfce;
-$margin: 16px;
+@import 'colors';
 
 .content-navigation {
   border-color: $blue;


### PR DESCRIPTION
This set of changes lets filters invalidate cached/compiled assets. There have been numerous occasions where I've changed a less file included by another less file and had to manually clear the cache/build output. This implements a basic recursive parser for CSS preprocessors and sprockets that allows the cacher/writer invalidate builds based on timestamps of the dependency trees.