### PR TITLE
Fix warning when using plugins with vendor namespaces

### DIFF
--- a/src/View/Helper/AssetCompressHelper.php
+++ b/src/View/Helper/AssetCompressHelper.php
@@ -295,7 +295,7 @@ class AssetCompressHelper extends Helper
         unset($plugins[$index]);
 
         if ($plugins) {
-            $pattern = '/(' . implode('|', $plugins) . ')/';
+            $pattern = '#(' . implode('|', $plugins) . ')#';
             if (preg_match($pattern, $path, $matches)) {
                 $pluginPath = Plugin::path($matches[1]) . 'webroot';
                 return str_replace($pluginPath, '/' . Inflector::underscore($matches[1]), $path);


### PR DESCRIPTION
Plugin names containing forward slashes (e.g. "AcmeCorp/ContactManager") terminate this regular expression too early.

    Warning (2): preg_match() [function.preg-match]: Unknown modifier 'C'

Changing the delimiter fixes this. Alternatively, using `preg_quote()` on each plugin name would work too.