### PR TITLE
Fix auto include functionality

### DIFF
--- a/src/View/Helper/AssetCompressHelper.php
+++ b/src/View/Helper/AssetCompressHelper.php
@@ -170,17 +170,19 @@ class AssetCompressHelper extends Helper
         if (!$this->autoInclude) {
             return;
         }
+
+        $controller = Inflector::underscore($this->request->param('controller'));
         $files = array(
-            $this->params['controller'] . '.js',
-            $this->params['controller'] . DS . $this->params['action'] . '.js'
+            $controller . '.js',
+            $controller . DS . $this->request->param('action') . '.js'
         );
 
         foreach ($files as $file) {
             $includeFile = Configure::read('App.jsBaseUrl') . $this->options['autoIncludePath'] . DS . $file;
-            if (file_exists($includeFile)) {
+            if (file_exists(WWW_ROOT . $includeFile)) {
                 $this->Html->script(
                     str_replace(DS, '/', $this->options['autoIncludePath'] . '/' . $file),
-                    array('inline' => false)
+                    array('block' => true)
                 );
             }
         }


### PR DESCRIPTION
Never tried [this functionality][1] before, but it required a few changes to get it working on the 3.0 branch.

[1]: https://github.com/markstory/asset_compress/wiki/Asset-Compress-Helper#auto-include-view-and-controller-javascript-files