### PR TITLE
Fix conflict with plugin-like assets

### DIFF
--- a/src/View/Helper/AssetCompressHelper.php
+++ b/src/View/Helper/AssetCompressHelper.php
@@ -234,11 +234,10 @@ class AssetCompressHelper extends Helper
         $index = array_search('AssetCompress', $plugins);
         unset($plugins[$index]);
 
-        if ($plugins) {
-            $pattern = '#(' . implode('|', $plugins) . ')#';
-            if (preg_match($pattern, $path, $matches)) {
-                $pluginPath = Plugin::path($matches[1]) . 'webroot';
-                return str_replace($pluginPath, '/' . Inflector::underscore($matches[1]), $path);
+        foreach ($plugins as $plugin) {
+            $pluginPath = Plugin::path($plugin) . 'webroot';
+            if (strpos($path, $pluginPath) === 0) {
+                return str_replace($pluginPath, '/' . Inflector::underscore($plugin), $path);
             }
         }
         $path = str_replace(WWW_ROOT, '/', $path);

--- a/tests/TestCase/FactoryTest.php
+++ b/tests/TestCase/FactoryTest.php
@@ -63,10 +63,11 @@ class FactoryTest extends TestCase
         $factory = new Factory($config);
         $collection = $factory->assetCollection();
 
-        $this->assertCount(3, $collection);
+        $this->assertCount(4, $collection);
         $this->assertTrue($collection->contains('libs.js'));
         $this->assertTrue($collection->contains('foo.bar.js'));
         $this->assertTrue($collection->contains('all.css'));
+        $this->assertTrue($collection->contains('blue-app.js'));
 
         $asset = $collection->get('libs.js');
         $this->assertCount(2, $asset->files(), 'Not enough files');

--- a/tests/TestCase/View/Helper/AssetCompressHelperTest.php
+++ b/tests/TestCase/View/Helper/AssetCompressHelperTest.php
@@ -476,4 +476,24 @@ EOF;
         $result = $this->Helper->inlineScript('libs.js');
         $this->assertEquals($expected, $result);
     }
+
+    /**
+     * test no conflict with plugin names
+     *
+     * @return void
+     */
+    public function testNoConflictWithPluginName()
+    {
+        Plugin::load('Blue');
+
+        $result = $this->Helper->script('blue-app.js', array('raw' => true));
+        $expected = array(
+            array(
+                'script' => array(
+                    'src' => '/js/BlueController.js'
+                )
+            )
+        );
+        $this->assertHtml($expected, $result);
+    }
 }

--- a/tests/test_files/config/integration.ini
+++ b/tests/test_files/config/integration.ini
@@ -20,3 +20,7 @@ paths[] = TEST_FILES/css/**
 
 [all.css]
 files[] = nav.css
+
+[blue-app.js]
+files[] = BlueController.js
+

--- a/tests/test_files/js/BlueController.js
+++ b/tests/test_files/js/BlueController.js
@@ -1,0 +1,1 @@
+// CSS used to check there are no conflict with plugin-like file paths


### PR DESCRIPTION
This PR enforces asset path checks against possible plugin files and generates proper paths when a file contains the plugin name but it's under app webroot folder.
Problem came up when I had a file named "NavbarSearchController.js" under my APP/webroot dir, and Cake's Search plugin was also loaded.