### PR TITLE
Fixed raw assets that exist in different paths

### DIFF
--- a/Lib/AssetScanner.php
+++ b/Lib/AssetScanner.php
@@ -131,7 +131,7 @@ class AssetScanner {
 				$exists = file_exists($fullPath);
 
 				if ($absolute === false && $exists) {
-					$expanded['relative'] = str_replace(WWW_ROOT, '/', $expanded['relative']);
+					$expanded['relative'] = str_replace($this->_getWebroot(), '/', $path . $expanded['relative']);
 				}
 				if ($exists) {
 					$expanded['absolute'] = $fullPath;
@@ -231,6 +231,15 @@ class AssetScanner {
 			}
 		}
 		return false;
+	}
+
+/**
+ * Gets webroot path
+ *
+ * @return string
+ */
+	protected function _getWebroot() {
+		return WWW_ROOT;
 	}
 
 }

--- a/Test/Case/Lib/AssetScannerTest.php
+++ b/Test/Case/Lib/AssetScannerTest.php
@@ -11,7 +11,11 @@ class AssetScannerTest extends CakeTestCase {
 			$this->_testFiles . 'js' . DS,
 			$this->_testFiles . 'js' . DS . 'classes' . DS
 		);
-		$this->Scanner = new AssetScanner($paths);
+		$this->Scanner = $this->getMock('AssetScanner', array('_getWebroot'), array($paths));
+		$this->Scanner
+			->expects($this->any())
+			->method('_getWebroot')
+			->will($this->returnValue($this->_testFiles));
 	}
 
 	public function testFind() {
@@ -20,9 +24,29 @@ class AssetScannerTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 
 		$result = $this->Scanner->find('base_class.js', false);
-		$this->assertEquals('base_class.js', $result, 'No WWW_ROOT replacement as it is a test file.');
+		$this->assertEquals('/js/classes/base_class.js', $result, 'No WWW_ROOT replacement as it is a test file.');
 
 		$this->assertFalse($this->Scanner->find('does not exist'));
+	}
+
+	public function testFindRelative() {
+		$paths = array(
+			$this->_testFiles . 'css' . DS,
+			$this->_testFiles . 'vendor' . DS
+		);
+		$scanner = $this->getMock('AssetScanner', array('_getWebroot'), array($paths));
+		$scanner
+			->expects($this->any())
+			->method('_getWebroot')
+			->will($this->returnValue($this->_testFiles));
+
+		$result = $scanner->find('vendor.css', false);
+		$expected = '/vendor/vendor.css';
+		$this->assertEquals($expected, $result);
+
+		$result = $scanner->find('nav.css', false);
+		$expected = '/css/nav.css';
+		$this->assertEquals($expected, $result);
 	}
 
 	public function testFindOtherExtension() {

--- a/Test/Case/View/Helper/AssetCompressHelperTest.php
+++ b/Test/Case/View/Helper/AssetCompressHelperTest.php
@@ -393,27 +393,44 @@ class AssetCompressHelperTest extends CakeTestCase {
 	}
 
 	public function testRawAssets() {
-		$config = $this->Helper->config();
+		$Config = AssetConfig::buildFromIniFile($this->_testFiles . 'Config' . DS . 'config.ini');
+
+		$paths = array(
+			$this->_testFiles . 'js' . DS
+		);
+
+		$helper = $this->getMock('AssetCompressHelper', array('_getScanner'), array(new View(), array('noconfig' => true)));
+		$helper->config($Config);
+
+		$scanner = $this->getMock('AssetScanner', array('_getWebroot'), array($paths, null));
+		$scanner
+			->expects($this->any())
+			->method('_getWebroot')
+			->will($this->returnValue($this->_testFiles));
+		$helper
+			->expects($this->any())
+			->method('_getScanner')
+			->will($this->returnValue($scanner));
+
+		$config = $helper->config();
 		$config->addTarget('raw.js', array(
 			'files' => array('classes/base_class.js', 'classes/base_class_two.js')
 		));
-		$config->paths('js', null, array(
-			$this->_testFiles . 'js' . DS
-		));
+		$config->paths('js', null, $paths);
 
-		$result = $this->Helper->script('raw.js', array('raw' => true));
+		$result = $helper->script('raw.js', array('raw' => true));
 		$expected = array(
 			array(
 				'script' => array(
 					'type' => 'text/javascript',
-					'src' => 'js/classes/base_class.js'
+					'src' => '/js/classes/base_class.js'
 				),
 			),
 			'/script',
 			array(
 				'script' => array(
 					'type' => 'text/javascript',
-					'src' => 'js/classes/base_class_two.js'
+					'src' => '/js/classes/base_class_two.js'
 				),
 			),
 			'/script',

--- a/Test/test_files/vendor/vendor.css
+++ b/Test/test_files/vendor/vendor.css
@@ -1,0 +1,3 @@
+.some_vendor_class {
+	content: 'hi';
+}

--- a/View/Helper/AssetCompressHelper.php
+++ b/View/Helper/AssetCompressHelper.php
@@ -293,7 +293,8 @@ class AssetCompressHelper extends AppHelper {
 		$output = '';
 		if (!empty($options['raw'])) {
 			unset($options['raw']);
-			$scanner = new AssetScanner($config->paths('css', $file), $this->theme);
+			$scanner = $this->_getScanner($config->paths('css', $file), $this->theme);
+
 			foreach ($buildFiles as $part) {
 				$part = $scanner->find($part, false);
 				$part = str_replace(DS, '/', $part);
@@ -333,7 +334,7 @@ class AssetCompressHelper extends AppHelper {
 		if (!empty($options['raw'])) {
 			$output = '';
 			unset($options['raw']);
-			$scanner = new AssetScanner($config->paths('js', $file), $this->theme);
+			$scanner = $this->_getScanner($config->paths('js', $file), $this->theme);
 			foreach ($buildFiles as $part) {
 				$part = $scanner->find($part, false);
 				$part = str_replace(DS, '/', $part);
@@ -563,5 +564,16 @@ class AssetCompressHelper extends AppHelper {
 		$results = $compiler->generate($file);
 
 		return $this->Html->tag('script', $results);
+	}
+
+/**
+ * Gets an instance of AssetScanner
+ *
+ * @param array $paths Paths
+ * @param string $theme Theme
+ * @return AssetScanner
+ */
+	protected function _getScanner($paths, $theme) {
+		return new AssetScanner($paths, $theme);
 	}
 }


### PR DESCRIPTION
I had the following in my config:

```
[css]
paths[] = WEBROOT/css/
paths[] = WEBROOT/vendor/

[styles]
; exists in css/
files[] = normalize.css
; exists in vendor/
files[] = chosen/chosen.min.css
```

When serving raw assets, the scanner replaced didn't take the assets actual relative path into account, so sources like `normalize.css` and `chosen/chosen.min.css` were assumed to be in the css folder. Building assets worked but serving raw ones didn't.

This fix takes paths that exist outside of standard asset folders (css, js) into account.