### PR TITLE
Handle square bracket arrays in addition to array()-style ones

### DIFF
--- a/Console/Command/Task/AssetBuildTask.php
+++ b/Console/Command/Task/AssetBuildTask.php
@@ -172,7 +172,8 @@ class AssetBuildTask extends AppShell {
 				break;
 			}
 			$token = array_shift($tokens);
-			if ($token[0] == T_ARRAY) {
+			// Both array() and [] style arrays
+			if ($token[0] == T_ARRAY || $token[0] == '[') {
 				$wasArray = true;
 				$files = $this->_parseArray($tokens);
 			}
@@ -182,6 +183,7 @@ class AssetBuildTask extends AppShell {
 				$files[] = trim($token[1], '"\'');
 			}
 		}
+		// Handle non-array for the files arg, ie addScript('file.js', 'output.js')
 		if (!$wasArray && count($files) == 2) {
 			$build = array_pop($files);
 		}
@@ -204,7 +206,7 @@ class AssetBuildTask extends AppShell {
 				$files[] = trim($token[1], '"\'');
 			}
 			// end of array
-			if ($token[0] === ')') {
+			if ($token[0] === ')' || $token[0] === ']') {
 				break;
 			}
 		}


### PR DESCRIPTION
I've recently updated my codebase from array() to [] (using this fantastic tool: https://github.com/thomasbachem/php-short-array-syntax-converter)

Here's how my old code looked:

```
$this->AssetCompress->addCss(array(
        '/../js/vendors/Nestable/nestable.css',
        'views/menus/edit.css',
), 'menu.css');
```

This worked fine. But my new updated (perfectly valid) code, throws AssetCompress for a loop.

```
$this->AssetCompress->addCss([
        '/../js/vendors/Nestable/nestable.css',
        'views/menus/edit.css',
], 'menu.css');
```

The output lists the filename as an md5 hash (and then gives an error that it cannot find the correctly named filename). I went digging and realized it was the parsing code, it was looking solely for array() and not []

Anyway, I think I fixed the issue, and all of my files build fine now. Let me know if there's anything wrong with my approach here.