### PR TITLE
[NotFoundException] Cannot not load filter "UglifyJs".

### DIFF
--- a/Config/asset_compress.sample.ini
+++ b/Config/asset_compress.sample.ini
@@ -44,7 +44,7 @@ filters[] = YuiJs
 files[] = jquery.js
 files[] = mootools.js
 files[] = class.js
-filters[] = UglifyJs
+filters[] = Uglifyjs
 
 ; Create the CSS extension
 [css]


### PR DESCRIPTION
Fix for [NotFoundException] Cannot not load filter "UglifyJs".
I've got this error on cakephp 2.x after fresh install. Today's morning found that filter should be called Uglifyjs instead of UglifyJs, cause filter is also called the same way https://github.com/markstory/asset_compress/blob/2.x/Lib/Filter/Uglifyjs.php
Thanks!