### PR TITLE
Add PSR7 middleware

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,0 +1,4 @@
+linters:
+  phpcs:
+    standard: CakePHP
+    extensions: '.php'

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -1,5 +1,18 @@
 <?php
 
+use AssetCompress\Middleware\AssetCompressMiddleware;
 use Cake\Routing\DispatcherFactory;
+use Cake\Core\Configure;
+use Cake\Event\EventManager;
 
-DispatcherFactory::add('AssetCompress.AssetCompressor');
+$appClass = Configure::read('App.namespace') . '\Application';
+if (class_exists($appClass)) {
+    // Bind the middleware class after the error handler, or at the end
+    // of the queue. We want to be after the error handler so 404's render nicely.
+    EventManager::instance()->on('Server.buildMiddleware', function ($queue) {
+        $middleware = new AssetCompressMiddleware();
+        $queue->insertAfter('Cake\Error\Middleware\ErrorHandlerMiddleware', $middleware);
+    });
+} else {
+    DispatcherFactory::add('AssetCompress.AssetCompressor');
+}

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -1,9 +1,9 @@
 <?php
 
 use AssetCompress\Middleware\AssetCompressMiddleware;
-use Cake\Routing\DispatcherFactory;
 use Cake\Core\Configure;
 use Cake\Event\EventManager;
+use Cake\Routing\DispatcherFactory;
 
 $appClass = Configure::read('App.namespace') . '\Application';
 if (class_exists($appClass)) {

--- a/src/Middleware/AssetCompressMiddleware.php
+++ b/src/Middleware/AssetCompressMiddleware.php
@@ -79,10 +79,19 @@ class AssetCompressMiddleware
         } catch (Exception $e) {
             throw new NotFoundException($e->getMessage());
         }
+
         return $this->respond($response, $contents, $build);
     }
 
-    private function respond($response, $contents, $build)
+    /**
+     * Respond with the asset.
+     *
+     * @param \Psr\Http\Message\ResponseInterface $response The response to augment
+     * @param string $contents The asset contents.
+     * @param \MiniAsset\AssetTarget $build The build target.
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    protected function respond($response, $contents, $build)
     {
         // Deliver built asset.
         $body = $response->getBody();
@@ -92,13 +101,20 @@ class AssetCompressMiddleware
         return $response->withHeader('Content-Type', $this->mapType($build));
     }
 
-    private function mapType($build)
+    /**
+     * Map an extension to a content type
+     *
+     * @param \MiniAsset\AssetTarget $build The build target.
+     * @return string The mapped content type.
+     */
+    protected function mapType($build)
     {
         $ext = $build->ext();
         $types = [
             'css' => 'application/css',
             'js' => 'application/javascript'
         ];
+
         return isset($types[$ext]) ? $types[$ext] : 'application/octet-stream';
     }
 

--- a/src/Middleware/AssetCompressMiddleware.php
+++ b/src/Middleware/AssetCompressMiddleware.php
@@ -1,0 +1,134 @@
+<?php
+namespace AssetCompress\Middleware;
+
+use AssetCompress\Config\ConfigFinder;
+use AssetCompress\Factory;
+use Cake\Core\Configure;
+use Cake\Network\Exception\NotFoundException;
+use MiniAsset\AssetConfig;
+
+/**
+ * PSR7 Compatible middleware for the new HTTP stack.
+ */
+class AssetCompressMiddleware
+{
+    /**
+     * Object containing configuration settings for asset compressor
+     *
+     * @var \AssetCompress\AssetConfig
+     */
+    protected $config;
+
+    /**
+     * Constructor
+     *
+     * @param \AssetCompress\AssetConfig $config The config object to use.
+     *   If null, \AssetCompress\ConfigFinder::loadAll() will be used.
+     */
+    public function __construct(AssetConfig $config = null)
+    {
+        if ($config === null) {
+            $finder = new ConfigFinder();
+            $config = $finder->loadAll();
+        }
+        $this->config = $config;
+    }
+
+    /**
+     * Get an asset or delegate to the next middleware
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request The request.
+     * @param \Psr\Http\Message\ResponseInterface $response The response.
+     * @param callable $next Callback to invoke the next middleware.
+     * @return \Psr\Http\Message\ResponseInterface A response
+     */
+    public function __invoke($request, $response, $next)
+    {
+        $config = $this->config;
+        $production = !Configure::read('debug');
+        if ($production && !$config->general('alwaysEnableController')) {
+            return $next($request, $response);
+        }
+
+        // Make sure the request looks like an asset.
+        $targetName = $this->getName($config, $request->getUri()->getPath());
+        if (!$targetName) {
+            return $next($request, $response);
+        }
+
+        $queryParams = $request->getQueryParams();
+        if (isset($queryParams['theme'])) {
+            $config->theme($queryParams['theme']);
+        }
+        $factory = new Factory($config);
+        $assets = $factory->assetCollection();
+        if (!$assets->contains($targetName)) {
+            return $next($request, $response);
+        }
+        $build = $assets->get($targetName);
+
+        try {
+            $compiler = $factory->compiler();
+            $cacher = $factory->cacher();
+            if ($cacher->isFresh($build)) {
+                $contents = $cacher->read($build);
+            } else {
+                $contents = $compiler->generate($build);
+                $cacher->write($build, $contents);
+            }
+        } catch (Exception $e) {
+            throw new NotFoundException($e->getMessage());
+        }
+        return $this->respond($response, $contents, $build);
+    }
+
+    private function respond($response, $contents, $build)
+    {
+        // Deliver built asset.
+        $body = $response->getBody();
+        $body->write($contents);
+        $body->rewind();
+
+        return $response->withHeader('Content-Type', $this->mapType($build));
+    }
+
+    private function mapType($build)
+    {
+        $ext = $build->ext();
+        $types = [
+            'css' => 'application/css',
+            'js' => 'application/javascript'
+        ];
+        return isset($types[$ext]) ? $types[$ext] : 'application/octet-stream';
+    }
+
+    /**
+     * Returns the build name for a requested asset
+     *
+     * @param \MiniAsset\AssetConfig $config The config object to use.
+     * @param string $url The url to get an asset name from.
+     * @return bool|string false if no build can be parsed from URL
+     * with url path otherwise
+     */
+    protected function getName($config, $url)
+    {
+        $parts = explode('.', $url);
+        if (count($parts) < 2) {
+            return false;
+        }
+
+        $path = $config->cachePath($parts[(count($parts) - 1)]);
+        if (empty($path)) {
+            return false;
+        }
+
+        $root = str_replace('\\', '/', WWW_ROOT);
+        $path = str_replace('\\', '/', $path);
+        $path = str_replace($root, '', $path);
+        if (strpos($url, $path) !== 0) {
+            return false;
+        }
+
+        return str_replace($path, '', $url);
+    }
+}

--- a/tests/TestCase/Config/ConfigFinderTest.php
+++ b/tests/TestCase/Config/ConfigFinderTest.php
@@ -22,7 +22,6 @@ class ConfigFinderTest extends TestCase
         parent::setUp();
         $this->_testFiles = APP;
         $this->testConfig = $this->_testFiles . 'config' . DS . 'config.ini';
-        $this->_themeConfig = $this->_testFiles . 'config' . DS . 'themed.ini';
 
         Plugin::load('TestAssetIni');
     }

--- a/tests/TestCase/Middleware/AssetCompressMiddlewareTest.php
+++ b/tests/TestCase/Middleware/AssetCompressMiddlewareTest.php
@@ -6,8 +6,8 @@ use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\TestSuite\TestCase;
 use MiniAsset\AssetConfig;
-use Zend\Diactoros\ServerRequest;
 use Zend\Diactoros\Response;
+use Zend\Diactoros\ServerRequest;
 
 class AssetsCompressMiddlewareTest extends TestCase
 {

--- a/tests/TestCase/Middleware/AssetCompressMiddlewareTest.php
+++ b/tests/TestCase/Middleware/AssetCompressMiddlewareTest.php
@@ -1,0 +1,120 @@
+<?php
+namespace AssetCompress\Test\TestCase\Middleware;
+
+use AssetCompress\Middleware\AssetCompressMiddleware;
+use Cake\Core\Configure;
+use Cake\Core\Plugin;
+use Cake\TestSuite\TestCase;
+use MiniAsset\AssetConfig;
+use Zend\Diactoros\ServerRequest;
+use Zend\Diactoros\Response;
+
+class AssetsCompressMiddlewareTest extends TestCase
+{
+
+    protected $nextInvoked = false;
+
+    /**
+     * Setup method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->testConfig = APP . 'config' . DS . 'integration.ini';
+        $this->nextInvoked = false;
+
+        $map = [
+            'WEBROOT' => WWW_ROOT,
+            'TEST_FILES' => APP
+        ];
+        Plugin::load('TestAssetIni');
+
+        $config = new AssetConfig([], $map);
+        $config->load($this->testConfig);
+        $config->load(APP . 'Plugin/TestAssetIni/config/asset_compress.ini', 'TestAssetIni.');
+        $config->load(APP . 'Plugin/TestAssetIni/config/asset_compress.local.ini', 'TestAssetIni.');
+
+        $this->middleware = new AssetCompressMiddleware($config);
+        $this->request = new ServerRequest();
+        $this->response = new Response();
+        $this->next = function () {
+            $this->nextInvoked = true;
+        };
+    }
+
+    /**
+     * teardown method.
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        parent::tearDown();
+        Plugin::unload('TestAssetIni');
+    }
+
+    /**
+     * test building assets interactively
+     *
+     * @return void
+     */
+    public function testBuildFile()
+    {
+        $uri = $this->request->getUri()->withPath('cache_js/libs.js');
+        $request = $this->request->withUri($uri);
+
+        $mw = $this->middleware;
+        $result = $mw($request, $this->response, $this->next);
+
+        $this->assertEquals('application/javascript', $result->getHeaderLine('Content-Type'));
+
+        $body = $result->getBody()->getContents();
+        $this->assertRegExp('/var BaseClass = new Class/', $body);
+        $this->assertRegExp('/var Template = new Class/', $body);
+    }
+
+    /**
+     * test building plugin assets.
+     *
+     * @return void
+     */
+    public function testPluginIniBuildFile()
+    {
+        Plugin::load('TestAssetIni');
+
+        $uri = $this->request->getUri()->withPath('cache_js/TestAssetIni.libs.js');
+        $request = $this->request->withUri($uri);
+
+        $mw = $this->middleware;
+        $result = $mw($request, $this->response, $this->next);
+
+        $this->assertEquals('application/javascript', $result->getHeaderLine('Content-Type'));
+
+        $body = $result->getBody()->getContents();
+        $this->assertRegExp('/var BaseClass = new Class/', $body);
+        $this->assertRegExp('/var Template = new Class/', $body);
+    }
+
+    /**
+     * test that predefined builds get cached to disk.
+     *
+     * @return void
+     */
+    public function testBuildFileIsCached()
+    {
+        $uri = $this->request->getUri()->withPath('cache_js/libs.js');
+        $request = $this->request->withUri($uri);
+
+        $mw = $this->middleware;
+        $result = $mw($request, $this->response, $this->next);
+
+        $body = $result->getBody()->getContents();
+        $this->assertEquals('application/javascript', $result->getHeaderLine('Content-Type'));
+        $this->assertContains('BaseClass', $body);
+
+        $this->assertTrue(file_exists(CACHE . 'asset_compress' . DS . 'libs.js'), 'Cache file was created.');
+        unlink(CACHE . 'asset_compress' . DS . 'libs.js');
+    }
+}


### PR DESCRIPTION
Mostly a clone of the dispatch filter, this adds a PSR7 middleware for AssetCompress, that is automatically used instead of the DispatchFilter if the host application is using PSR7 HTTP stack.