### PR TITLE
Upgrade to mini-asset 1.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	},
 	"require": {
 		"cakephp/cakephp": ">=3.3.3 <4.0.0",
-		"markstory/mini-asset": ">=0.0.1 <2.0.0"
+		"markstory/mini-asset": ">=1.3.0 <2.0.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "4.1.*",

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -36,6 +36,19 @@ class Factory extends BaseFactory
     }
 
     /**
+     * Create a Caching Compiler
+     *
+     * @param bool $debug Whether or not to enable debugging mode for the compiler.
+     * @return \MiniAsset\Output\CachedCompiler
+     */
+    public function cachedCompiler($outputDir = '', $debug = false)
+    {
+        $outputDir = $outputDir ?: CACHE . 'asset_compress' . DS;
+        $debug = $debug ?: Configure::read('debug');
+        return parent::cachedCompiler($outputDir, $debug);
+    }
+
+    /**
      * Create an AssetCacher
      *
      * @param string $path The path to read from. Defaults to the application CACHE path.

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -38,6 +38,7 @@ class Factory extends BaseFactory
     /**
      * Create a Caching Compiler
      *
+     * @param string $outputDir The directory to output cached files to.
      * @param bool $debug Whether or not to enable debugging mode for the compiler.
      * @return \MiniAsset\Output\CachedCompiler
      */
@@ -45,6 +46,7 @@ class Factory extends BaseFactory
     {
         $outputDir = $outputDir ?: CACHE . 'asset_compress' . DS;
         $debug = $debug ?: Configure::read('debug');
+
         return parent::cachedCompiler($outputDir, $debug);
     }
 

--- a/src/Middleware/AssetCompressMiddleware.php
+++ b/src/Middleware/AssetCompressMiddleware.php
@@ -68,14 +68,8 @@ class AssetCompressMiddleware
         $build = $assets->get($targetName);
 
         try {
-            $compiler = $factory->compiler();
-            $cacher = $factory->cacher();
-            if ($cacher->isFresh($build)) {
-                $contents = $cacher->read($build);
-            } else {
-                $contents = $compiler->generate($build);
-                $cacher->write($build, $contents);
-            }
+            $compiler = $factory->cachedCompiler();
+            $contents = $compiler->generate($build);
         } catch (Exception $e) {
             throw new NotFoundException($e->getMessage());
         }

--- a/src/Routing/Filter/AssetCompressorFilter.php
+++ b/src/Routing/Filter/AssetCompressorFilter.php
@@ -61,14 +61,8 @@ class AssetCompressorFilter extends DispatcherFilter
         $build = $assets->get($targetName);
 
         try {
-            $compiler = $factory->compiler();
-            $cacher = $factory->cacher();
-            if ($cacher->isFresh($build)) {
-                $contents = $cacher->read($build);
-            } else {
-                $contents = $compiler->generate($build);
-                $cacher->write($build, $contents);
-            }
+            $compiler = $factory->cachedCompiler();
+            $contents = $compiler->generate($build);
         } catch (Exception $e) {
             throw new NotFoundException($e->getMessage());
         }

--- a/tests/TestCase/FactoryTest.php
+++ b/tests/TestCase/FactoryTest.php
@@ -206,4 +206,19 @@ class FactoryTest extends TestCase
         $compiler = $factory->compiler();
         $this->assertAttributeEquals(false, 'debug', $compiler);
     }
+
+    public function testCachedCompiler()
+    {
+        $config = AssetConfig::buildFromIniFile($this->overrideFile, [
+            'WEBROOT' => APP
+        ]);
+        $factory = new Factory($config);
+        $compiler = $factory->cachedCompiler();
+
+        $innerCompiler = $this->readAttribute($compiler, 'compiler');
+        $this->assertAttributeEquals(true, 'debug', $innerCompiler);
+
+        $cacher = $this->readAttribute($compiler, 'cacher');
+        $this->assertAttributeEquals(CACHE . 'asset_compress' . DS, 'path', $cacher);
+    }
 }


### PR DESCRIPTION
Use the new cachedCompiler to make Middleware/Filter simpler and better enable intermediate builds supported by MiniAsset 1.3.0
