### PR TITLE
Added support for general.timestampPath

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   },
   "require": {
     "cakephp/cakephp": ">=3.3.3 <4.0.0",
-    "markstory/mini-asset": ">=1.3.0 <2.0.0"
+    "markstory/mini-asset": ">=1.4.0 <2.0.0"
   },
   "require-dev": {
     "phpunit/phpunit": "5.*",

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -32,7 +32,7 @@ class Factory extends BaseFactory
      */
     public function writer($path = TMP)
     {
-        return parent::writer($path);
+        return parent::writer($this->config->get('general.timestampPath') ?: $path);
     }
 
     /**

--- a/src/Shell/AssetCompressShell.php
+++ b/src/Shell/AssetCompressShell.php
@@ -126,7 +126,6 @@ class AssetCompressShell extends Shell
             return $target->name();
         }, iterator_to_array($assets));
 
-
         $this->_clearPath(CACHE . 'asset_compress' . DS, $themes, $targets);
         $this->_clearPath($this->config->cachePath('js'), $themes, $targets);
         $this->_clearPath($this->config->cachePath('css'), $themes, $targets);

--- a/src/View/Helper/AssetCompressHelper.php
+++ b/src/View/Helper/AssetCompressHelper.php
@@ -291,7 +291,6 @@ class AssetCompressHelper extends Helper
         $baseUrl = $config->get($type . '.baseUrl');
         $devMode = Configure::read('debug');
 
-
         // CDN routes.
         if ($baseUrl && !$devMode) {
             return $baseUrl . $this->_getBuildName($target);

--- a/tests/TestCase/FactoryTest.php
+++ b/tests/TestCase/FactoryTest.php
@@ -20,6 +20,7 @@ class FactoryTest extends TestCase
         $this->themedFile = APP . 'config' . DS . 'themed.ini';
         $this->pluginFile = APP . 'config' . DS . 'plugins.ini';
         $this->overrideFile = APP . 'config' . DS . 'overridable.local.ini';
+        $this->timestampFile = APP . 'config' . DS . 'timestamp.ini';
     }
 
     public function testFilterRegistry()
@@ -189,6 +190,26 @@ class FactoryTest extends TestCase
             ],
             'path' => TMP,
             'theme' => 'Red'
+        ];
+        $this->assertEquals($expected, $writer->config());
+    }
+
+    public function testWriterWithTimestampPath()
+    {
+        $config = AssetConfig::buildFromIniFile($this->timestampFile, [
+            'TEST_FILES' => APP,
+            'WEBROOT' => TMP
+        ]);
+        $factory = new Factory($config);
+        $writer = $factory->writer();
+
+        $expected = [
+            'timestamp' => [
+                'js' => true,
+                'css' => false
+            ],
+            'path' => TMP . 'timestamp' . DIRECTORY_SEPARATOR,
+            'theme' => '',
         ];
         $this->assertEquals($expected, $writer->config());
     }

--- a/tests/test_files/config/timestamp.ini
+++ b/tests/test_files/config/timestamp.ini
@@ -1,0 +1,11 @@
+; A mostly empty config file to test timestamping
+;
+[General]
+writeCache = true
+timestampPath=WEBROOT/timestamp
+
+[js]
+timestamp=true
+
+[libs.js]
+files[] = class.js


### PR DESCRIPTION
Depends on git@github.com:jeremyharris/asset_compress.git

Well, sort of. It'll work just fine but won't parse constants until the above is released. This can be on hold until I make any required composer updates.