### PR TITLE
Issue #329 -- Editing a SASS partial in v0.20 does not trigger the ou…

### DIFF
--- a/Lib/AssetCache.php
+++ b/Lib/AssetCache.php
@@ -43,93 +43,93 @@ class AssetCache {
  * @param string $target The target file being built.
  * @return boolean
  */
-    public function isFresh($target) {
-        $ext = $this->_Config->getExt($target);
-        $files = $this->_Config->files($target);
+	public function isFresh($target) {
+		$ext = $this->_Config->getExt($target);
+		$files = $this->_Config->files($target);
 
-        $theme = $this->_Config->theme();
-        $target = $this->buildFileName($target);
+		$theme = $this->_Config->theme();
+		$target = $this->buildFileName($target);
 
-        $buildFile = $this->_Config->cachePath($ext) . $target;
+		$buildFile = $this->_Config->cachePath($ext) . $target;
 
-        if (!file_exists($buildFile)) {
-            return false;
-        }
-        $configTime = $this->_Config->modifiedTime();
-        $buildTime = filemtime($buildFile);
+		if (!file_exists($buildFile)) {
+			return false;
+		}
+		$configTime = $this->_Config->modifiedTime();
+		$buildTime = filemtime($buildFile);
 
-        if ($configTime >= $buildTime) {
-            return false;
-        }
+		if ($configTime >= $buildTime) {
+			return false;
+		}
 
-        $Scanner = new AssetScanner($this->_Config->paths($ext, $target), $theme);
+		$Scanner = new AssetScanner($this->_Config->paths($ext, $target), $theme);
 
-        foreach ($files as $file) {
-            $path = $Scanner->find($file);
-            if ($Scanner->isRemote($path)) {
-                $time = $this->getRemoteFileLastModified($path);
-            } else {
-                $time = filemtime($path);
-            }
-            if ($time === false || $time >= $buildTime) {
-                return false;
-            }
+		foreach ($files as $file) {
+			$path = $Scanner->find($file);
+			if ($Scanner->isRemote($path)) {
+				$time = $this->getRemoteFileLastModified($path);
+			} else {
+				$time = filemtime($path);
+			}
+			if ($time === false || $time >= $buildTime) {
+				return false;
+			}
 
-            // If this is a SASS or LESS file, check any imports defined to see if they are not fresh.
-            $currentFileExt = $this->_Config->getExt($file);
-            $isSass = $currentFileExt === 'scss';
-            $isLess = $currentFileExt === 'less';
+			// If this is a SASS or LESS file, check any imports defined to see if they are not fresh.
+			$currentFileExt = $this->_Config->getExt($file);
+			$isSass = $currentFileExt === 'scss';
+			$isLess = $currentFileExt === 'less';
 
-            if ($isSass || $isLess) {
-                $content = '';
-                if ($Scanner->isRemote($path)) {
-                    $handle = fopen($path, 'rb');
-                    if ($handle) {
-                        $content = stream_get_contents($handle);
-                        fclose($handle);
-                    }
-                } else {
-                    $content = file_get_contents($path);
-                }
+			if ($isSass || $isLess) {
+				$content = '';
+				if ($Scanner->isRemote($path)) {
+					$handle = fopen($path, 'rb');
+					if ($handle) {
+						$content = stream_get_contents($handle);
+						fclose($handle);
+					}
+				} else {
+					$content = file_get_contents($path);
+				}
 
-                $importPattern = '/^\s*@import\s*(?:(?:([\'"])([^\'"]+)\\1)|(?:url\(([\'"])([^\'"]+)\\3\)))(\s.*)?;/m';
-                preg_match_all($importPattern, $content, $matches, PREG_SET_ORDER);
+				$importPattern = '/^\s*@import\s*(?:(?:([\'"])([^\'"]+)\\1)|(?:url\(([\'"])([^\'"]+)\\3\)))(\s.*)?;/m';
+				preg_match_all($importPattern, $content, $matches, PREG_SET_ORDER);
 
-                if (!empty($matches)) {
-                    foreach ($matches as $match) {
-                        $importPath = empty($match[2]) ? $match[4] : $match[2];
+				if (!empty($matches)) {
+					foreach ($matches as $match) {
+						$importPath = empty($match[2]) ? $match[4] : $match[2];
 
-                        // Transform file based import paths for SASS
-                        if ($isSass && preg_match('/^(url\(|http).*/', $importPath) === 0) {
-                            $importPath .= '.scss';
+						// Transform file based import paths for SASS
+						if ($isSass && preg_match('/^(url\(|http).*/', $importPath) === 0) {
+							$importPath .= '.scss';
 
-                            if (strpos($importPath, '/') !== false) {
-                                $lastSlashPosition = strrpos($importPath, '/');
-                                $importPath = substr($importPath, 0, $lastSlashPosition + 1) . '_' . substr($importPath, $lastSlashPosition + 1);
-                            } else {
-                                $importPath = '_' . $importPath;
-                            }
-                        } else {
-                            $importPath = str_replace(['url("', ');'], '', $importPath);
-                        }
+							if (strpos($importPath, '/') !== false) {
+								$lastSlashPosition = strrpos($importPath, '/');
+								$importPath = substr($importPath, 0, $lastSlashPosition + 1) . '_' . substr($importPath, $lastSlashPosition + 1);
+							} else {
+								$importPath = '_' . $importPath;
+							}
+						} else {
+							$importPath = str_replace(['url("', ');'], '', $importPath);
+						}
 
-                        $importFile = $Scanner->find($importPath, false);
+						$importFile = $Scanner->find($importPath, false);
 
-                        if ($Scanner->isRemote($importFile)) {
-                            $time = $this->getRemoteFileLastModified($importFile);
-                        } else {
-                            $time = filemtime($importFile);
-                        }
+						if ($Scanner->isRemote($importFile)) {
+							$time = $this->getRemoteFileLastModified($importFile);
+						} else {
+							$time = filemtime($importFile);
+						}
 
-                        if ($time === false || $time >= $buildTime) {
-                            return false;
-                        }
-                    }
-                }
-            }
-        }
-        return true;
-    }
+						if ($time === false || $time >= $buildTime) {
+							return false;
+						}
+					}
+				}
+			}
+		}
+		return true;
+	}
 
 /**
  * Gets the modification time of a remote $url.

--- a/Lib/AssetCache.php
+++ b/Lib/AssetCache.php
@@ -66,9 +66,9 @@ class AssetCache {
 
 		foreach ($files as $file) {
 			$path = $Scanner->find($file);
-            if (!$this->_isFreshTimestamp($Scanner, $path, $buildTime)) {
-                return false;
-            }
+			if (!$this->_isFreshTimestamp($Scanner, $path, $buildTime)) {
+				return false;
+			}
 
 			$currentFileExt = $this->_Config->getExt($file);
 

--- a/Lib/AssetCache.php
+++ b/Lib/AssetCache.php
@@ -66,7 +66,7 @@ class AssetCache {
 
 		foreach ($files as $file) {
 			$path = $Scanner->find($file);
-            if (!$this->_isFreshTimestamp($Scanner, $file, $buildTime)) {
+            if (!$this->_isFreshTimestamp($Scanner, $path, $buildTime)) {
                 return false;
             }
 

--- a/Lib/AssetCache.php
+++ b/Lib/AssetCache.php
@@ -329,7 +329,7 @@ class AssetCache {
 		return $this->_isSass($fileExt) || $this->_isLess($fileExt);
 	}
 
-	/**
+/**
  * Check if a file is a SASS file
  *
  * @param string $fileExt The file extension.

--- a/Test/Case/Lib/AssetCacheTest.php
+++ b/Test/Case/Lib/AssetCacheTest.php
@@ -83,7 +83,7 @@ class AssetCacheTest extends CakeTestCase {
 		$cache = new AssetCache($config);
 		$this->assertTrue($cache->isFresh('import.scss'));
 
-        unlink(TMP . '/libs.js');
+		unlink(TMP . '/libs.js');
 		unlink(TMP . '/import.css');
 	}
 

--- a/Test/Case/Lib/AssetCacheTest.php
+++ b/Test/Case/Lib/AssetCacheTest.php
@@ -55,6 +55,8 @@ class AssetCacheTest extends CakeTestCase {
 
 	public function testIsFreshConfigExpire() {
 		touch(TMP . '/libs.js');
+		touch(TMP . '/import.css');
+		touch(App::pluginPath('AssetCompress') . 'Test' . DS . 'test_files' . DS . 'css' . DS . '_sass_partial.css');
 
 		$data = parse_ini_file($this->testConfig, true);
 		$constants = array(
@@ -74,7 +76,15 @@ class AssetCacheTest extends CakeTestCase {
 		$cache = new AssetCache($config);
 		$this->assertFalse($cache->isFresh('libs.js'));
 
-		unlink(TMP . '/libs.js');
+		$config = new AssetConfig($data, $constants, strtotime('+1 minute'));
+		$config->cachePath('css', TMP);
+		$config->set('css.timestamp', false);
+
+		$cache = new AssetCache($config);
+		$this->assertTrue($cache->isFresh('import.scss'));
+
+        unlink(TMP . '/libs.js');
+		unlink(TMP . '/import.css');
 	}
 
 	public function testThemeFileSaving() {
@@ -134,22 +144,22 @@ class AssetCacheTest extends CakeTestCase {
 		$result = $this->cache->buildFilename('libs.js');
 		$this->assertEquals('libs.v' . $time . '.js', $result);
 	}
-	
+
 	public function testInvalidateAndFinalizeBuildTimestamp() {
 		$this->config->general('cacheConfig', true);
 		$this->config->set('js.timestamp', true);
-		
+
 		$cacheName = $this->cache->buildCacheName('libs.js');
 		$this->cache->invalidate('libs.js');
 		$invalidatedCacheName = $this->cache->buildCacheName('libs.js');
 		$this->assertNotEquals($cacheName, $invalidatedCacheName);
-		
+
 		$time = $this->cache->getTimestamp('libs.js');
-		
+
 		$this->cache->finalize('libs.js');
 		$finalizedCacheName = $this->cache->buildCacheName('libs.js');
 		$this->assertEquals($cacheName, $finalizedCacheName);
-		
+
 		$finalizedTime = $this->cache->getTimestamp('libs.js');
 		$this->assertEquals($time, $finalizedTime);
 	}

--- a/Test/Case/Lib/AssetCacheTest.php
+++ b/Test/Case/Lib/AssetCacheTest.php
@@ -81,7 +81,7 @@ class AssetCacheTest extends CakeTestCase {
 		$config->set('css.timestamp', false);
 
 		$cache = new AssetCache($config);
-		$this->assertTrue($cache->isFresh('import.scss'));
+		$this->assertFalse($cache->isFresh('import.scss'));
 
 		unlink(TMP . '/libs.js');
 		unlink(TMP . '/import.css');

--- a/Test/test_files/css/_sass_partial.scss
+++ b/Test/test_files/css/_sass_partial.scss
@@ -1,0 +1,3 @@
+.some-element {
+    background-color: red;;
+}

--- a/Test/test_files/css/import.scss
+++ b/Test/test_files/css/import.scss
@@ -1,0 +1,1 @@
+@import "_sass_partial";


### PR DESCRIPTION
…tput CSS file to be regenerated when "always enable controller" is false

Alter the `isFresh()` method to detect a SASS or LESS file being processed. If one of those types, get the file contents and check for any import statements. If any import statements, check the freshness of those files.

Kept it at one level of import checking. Not sure how common nesting imports is. I'm not familiar enough with LESS or have an environment to test that code path, but the SASS path works in my local environment.