### PR TITLE
Make errors visible

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,11 @@
+# Define the line ending behavior of the different file extensions
+# Set default behavior, in case users don't have core.autocrlf set.
+* text text=auto eol=lf
+
 # Remove files for archives generated using `git archive`
 .gitattributes export-ignore
 .gitignore export-ignore
 phpunit.xml.dist export-ignore
 .travis.yml export-ignore
+.editorconfig export-ignore
 tests/ export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,18 @@ language: php
 
 php:
   - 7.2
-  - 7.3
+  - 7.4
 
 env:
   global:
     - DEFAULT=1
-  
+
 matrix:
   fast_finish: true
 
   include:
     - php: 7.3
-      env: PHPCS=1 DEFAULT=0
+      env: CHECKS=1 DEFAULT=0
 
     - php: 7.3
       env: COVERAGE=1 DEFAULT=0
@@ -22,19 +22,20 @@ before_script:
   - phpenv rehash
 
 install:
-  - composer self-update
   - composer install --prefer-dist --no-interaction --dev
-  - if [[ $PHPSTAN = 1 ]]; then composer stan-setup; fi
+
+  - if [[ $CHECKS = 1 ]]; then composer stan-setup; fi
 
 script:
   - if [[ $DEFAULT = 1 ]]; then composer test; fi
   - if [[ $COVERAGE = 1 ]]; then composer coverage-test; fi
-  - if [[ $PHPCS = 1 ]]; then composer cs-check; fi
-  - if [[ $PHPSTAN = 1 ]]; then composer stan; fi
+
+  - if [[ $CHECKS = 1 ]]; then composer cs-check; fi
+  - if [[ $CHECKS = 1 ]]; then composer stan; fi
 
 after_success:
   - if [[ $COVERAGE = 1 ]]; then bash <(curl -s https://codecov.io/bash); fi
 
-  
+
 notifications:
   email: false

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "stan": "phpstan analyse src/ && psalm --show-info=false",
         "stan-test": "phpstan analyse tests/",
         "psalm": "psalm",
-        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^0.11 vimeo/psalm:^3.0 && mv composer.backup composer.json",
+        "stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^0.12 vimeo/psalm:^3.0 && mv composer.backup composer.json",
         "coverage-test": "phpunit --stderr --coverage-clover=clover.xml"
     }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <ruleset name="CakePHP Core">
- <rule ref="./vendor/cakephp/cakephp-codesniffer/CakePHP/ruleset.xml" />
+    <rule ref="./vendor/cakephp/cakephp-codesniffer/CakePHP/ruleset.xml"/>
 
- <exclude-pattern>tests/test_files/js/*</exclude-pattern>
- <exclude-pattern>tests/test_files/css/*</exclude-pattern>
+    <exclude-pattern>tests/test_files/js/*</exclude-pattern>
+    <exclude-pattern>tests/test_files/css/*</exclude-pattern>
 </ruleset>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 parameters:
-    level: 6
+    level: 5
+    checkMissingIterableValueType: false
     autoload_files:
         - tests/bootstrap.php
     ignoreErrors:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-	bootstrap="./tests/bootstrap.php"
+	bootstrap="tests/bootstrap.php"
 	>
 
 	<testsuites>
-		<testsuite name="AssetCompress Test Cases">
-			<directory>./tests/</directory>
+		<testsuite name="asset-compress">
+			<directory>tests/</directory>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/src/View/Helper/AssetCompressHelper.php
+++ b/src/View/Helper/AssetCompressHelper.php
@@ -19,6 +19,8 @@ use RuntimeException;
  *
  * Handle inclusion assets using the AssetCompress features for concatenating and
  * compressing asset files.
+ *
+ * @property \Cake\View\Helper\HtmlHelper $Html
  */
 class AssetCompressHelper extends Helper
 {


### PR DESCRIPTION
phpstan was never run in travis, so the bugs are currently invisible
this makes the issues in code now visible

I also ran 

    bin/cake annotate all -p AssetCompress

which further removes some warnings

The rest is still in need to fixed, especially the bug around force:

    empty($this->params['force']))

etc

Other issues left:
- middleware deprecated (not using new interface, violating contract of the middleware stack)
- small docblock/types errors