### PR TITLE
Remove targets other than js and css, too

### DIFF
--- a/src/Command/ClearCommand.php
+++ b/src/Command/ClearCommand.php
@@ -82,13 +82,14 @@ class ClearCommand extends Command
 
             return;
         }
-        $targets = array_map(function ($target) {
-            return $target->name();
-        }, iterator_to_array($assets));
+
+        $targets = [];
+        foreach (iterator_to_array($assets) as $target) {
+            $this->clearPath($io, $target->outputDir() . DS, $themes, [ $target->name() ]);
+            $targets[] = $target->name();
+        }
 
         $this->clearPath($io, CACHE . 'asset_compress' . DS, $themes, $targets);
-        $this->clearPath($io, $config->cachePath('js'), $themes, $targets);
-        $this->clearPath($io, $config->cachePath('css'), $themes, $targets);
     }
 
     /**

--- a/src/Command/ClearCommand.php
+++ b/src/Command/ClearCommand.php
@@ -85,7 +85,7 @@ class ClearCommand extends Command
 
         $targets = [];
         foreach (iterator_to_array($assets) as $target) {
-            $this->clearPath($io, $target->outputDir() . DS, $themes, [ $target->name() ]);
+            $this->clearPath($io, $target->outputDir() . DS, $themes, [$target->name()]);
             $targets[] = $target->name();
         }
 

--- a/tests/TestCase/Command/AssetCompressCommandsTest.php
+++ b/tests/TestCase/Command/AssetCompressCommandsTest.php
@@ -25,6 +25,7 @@ class AssetCompressCommandsTest extends TestCase
         $this->testConfig = APP . 'config' . DS;
         mkdir(WWW_ROOT . 'cache_js');
         mkdir(WWW_ROOT . 'cache_css');
+        mkdir(WWW_ROOT . 'cache_svg');
 
         $this->loadPlugins(['AssetCompress']);
         $this->useCommandRunner();
@@ -42,6 +43,8 @@ class AssetCompressCommandsTest extends TestCase
         $dir = new Folder(WWW_ROOT . 'cache_js');
         $dir->delete();
         $dir = new Folder(WWW_ROOT . 'cache_css');
+        $dir->delete();
+        $dir = new Folder(WWW_ROOT . 'cache_svg');
         $dir->delete();
     }
 
@@ -92,6 +95,7 @@ class AssetCompressCommandsTest extends TestCase
             WWW_ROOT . 'cache_css/all.v12354.css',
             WWW_ROOT . 'cache_js/libs.js',
             WWW_ROOT . 'cache_js/libs.v12354.js',
+            WWW_ROOT . 'cache_svg/foo.bar.svg',
         ];
         foreach ($files as $file) {
             touch($file);

--- a/tests/TestCase/FactoryTest.php
+++ b/tests/TestCase/FactoryTest.php
@@ -61,11 +61,12 @@ class FactoryTest extends TestCase
         $factory = new Factory($config);
         $collection = $factory->assetCollection();
 
-        $this->assertCount(4, $collection);
+        $this->assertCount(5, $collection);
         $this->assertTrue($collection->contains('libs.js'));
         $this->assertTrue($collection->contains('foo.bar.js'));
         $this->assertTrue($collection->contains('all.css'));
         $this->assertTrue($collection->contains('blue-app.js'));
+        $this->assertTrue($collection->contains('foo.bar.svg'));
 
         $asset = $collection->get('libs.js');
         $this->assertCount(2, $asset->files(), 'Not enough files');

--- a/tests/test_files/config/integration.ini
+++ b/tests/test_files/config/integration.ini
@@ -23,3 +23,9 @@ files[] = nav.css
 [blue-app.js]
 files[] = BlueController.js
 
+[svg]
+cachePath = WWW_ROOT/cache_svg
+paths[] = APP/svg/**
+
+[foo.bar.svg]
+files[] = ellipse.svg

--- a/tests/test_files/svg/ellipse.svg
+++ b/tests/test_files/svg/ellipse.svg
@@ -1,0 +1,6 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="50">
+    <ellipse cx="50" cy="25" rx="50" ry="25" style="fill:blue;"/>
+</svg>


### PR DESCRIPTION
Currently, `cake asset_compress clear` only removes targets that are JS or CSS. This PR makes the command remove all the target files regardless of their extension.