### PR TITLE
Fix Travis CI setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
   - phpenv rehash
 
 install:
-  - composer install --prefer-dist --no-interaction --dev
+  - composer install --prefer-dist --no-interaction
 
   - if [[ $CHECKS = 1 ]]; then composer stan-setup; fi
 


### PR DESCRIPTION
# Changed log

- Remove `--dev` option for `composer install --prefer-dist --no-interaction` command because it's deprecated:

```
You are using the deprecated option "--dev". It has no effect and will break in Composer 3.
```