### PR TITLE
Update BuildCommand.php - fixed force param condition check

### DIFF
--- a/src/Command/BuildCommand.php
+++ b/src/Command/BuildCommand.php
@@ -96,7 +96,7 @@ class BuildCommand extends Command
         $compiler = $factory->compiler();
 
         $name = $writer->buildFileName($build);
-        if ($writer->isFresh($build) && $args->getOption('force')) {
+        if ($writer->isFresh($build) && $args->getOption('force') === false) {
             $io->out('<info>Skip building</info> ' . $name . ' existing file is still fresh.');
 
             return;


### PR DESCRIPTION
Fixed condition for check of force option.
Previously if we put anything as force option it converted to true, which skipped building. While the expected behaviour was to create new build.